### PR TITLE
test: Replaced instances of 'localhost' with '127.0.0.1'

### DIFF
--- a/test/integrations/integration_test.go
+++ b/test/integrations/integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var BASEURL = "http://localhost:8000"
+var BASEURL = "http://127.0.0.1:8000"
 
 func TestMain(m *testing.M) {
 	setup()

--- a/ui/src/ProductConstants.cs
+++ b/ui/src/ProductConstants.cs
@@ -68,7 +68,7 @@ namespace FirefoxPrivateNetwork
         /// {1} - Current platform (e.g. WINNT_x86_64).
         /// </summary>
 #if DEBUG_QA
-        public const string UpdateTemplateUrl = "http://localhost:8080/json/1/FirefoxVPN/{0}/{1}/release/update.json";
+        public const string UpdateTemplateUrl = "http://127.0.0.1:8080/json/1/FirefoxVPN/{0}/{1}/release/update.json";
 #else
         public const string UpdateTemplateUrl = "https://aus5.mozilla.org/json/1/FirefoxVPN/{0}/{1}/release/update.json";
 #endif
@@ -152,7 +152,7 @@ namespace FirefoxPrivateNetwork
         /// Gets or sets the currently used base URL for communicating with FxA.
         /// </summary>
 #if DEBUG_QA
-        public static string BaseUrl = "http://localhost:8080";
+        public static string BaseUrl = "http://127.0.0.1:8080";
 #else
         public static string BaseUrl { get; set; } = "https://fpn.firefox.com";
 #endif

--- a/ui/src/WCF/Tester.cs
+++ b/ui/src/WCF/Tester.cs
@@ -23,12 +23,12 @@ namespace FirefoxPrivateNetwork.WCF
         [Conditional("DEBUG_QA")]
         public static void OpenConnection()
         {
-            host = new WebServiceHost(typeof(Service), new Uri("http://localhost:8000/"));
+            host = new WebServiceHost(typeof(Service), new Uri("http://127.0.0.1:8000/"));
             try
             {
                 ServiceEndpoint ep = host.AddServiceEndpoint(typeof(IService), new WebHttpBinding(), string.Empty);
                 host.Open();
-                ChannelFactory<IService> cf = new ChannelFactory<IService>(new WebHttpBinding(), "http://localhost:8000");
+                ChannelFactory<IService> cf = new ChannelFactory<IService>(new WebHttpBinding(), "http://127.0.0.1:8000");
                 cf.Endpoint.EndpointBehaviors.Add(new WebHttpBehavior());
                 IService channel = cf.CreateChannel();
             }


### PR DESCRIPTION
In order to avoid IPv4/IPv6 confusion within the CI process, we should stick with 127.0.0.1 for now.