### PR TITLE
UI: Fixed issue where MSI upgrade would trigger a restart

### DIFF
--- a/ui/src/UI/Resources/Localization/Translations/de.ftl
+++ b/ui/src/UI/Resources/Localization/Translations/de.ftl
@@ -124,6 +124,7 @@ update-title = Sicherheitsupdate
 update-content-1 = Update {application-name}, um es weiter zu verwenden
 update-content-2 = Die Verbindung ist während des Updateprozesses nicht sicher.
 update-update-button-text = Update starten
+update-update-failed-georestricted = Updates are only available for users located in the US
 update-update-failed = Update fehler
 update-update-started = Update starten
 

--- a/ui/src/UI/Resources/Localization/Translations/en-us.ftl
+++ b/ui/src/UI/Resources/Localization/Translations/en-us.ftl
@@ -126,6 +126,7 @@ update-content-2 = Your connection will not be secure while you update.
 update-update-button-text = Update now
 update-update-failed = Update failed
 update-update-started = Update started
+update-update-failed-georestricted = Updates are only available for users located in the US
 
 ## New User Experience
 nux-title-1 = No activity logs

--- a/ui/src/UI/Views/UpdateView.xaml.cs
+++ b/ui/src/UI/Views/UpdateView.xaml.cs
@@ -41,10 +41,22 @@ namespace FirefoxPrivateNetwork.UI
 
             var updateTask = Task.Run(async () =>
             {
-                var success = await Update.Update.Run(ProductConstants.GetNumericVersion());
-                if (!success)
+                var updateResult = await Update.Update.Run(ProductConstants.GetNumericVersion());
+
+                switch (updateResult)
                 {
-                    ErrorHandling.ErrorHandler.Handle(new ErrorHandling.UserFacingMessage("update-update-failed"), ErrorHandling.UserFacingErrorType.Toast, ErrorHandling.UserFacingSeverity.ShowError, ErrorHandling.LogLevel.Error);
+                    case Update.Update.UpdateResult.DisconnectTimeout:
+                    case Update.Update.UpdateResult.GeneralFailure:
+                    case Update.Update.UpdateResult.HttpError:
+                    case Update.Update.UpdateResult.InvalidSignature:
+                    case Update.Update.UpdateResult.SuccessNoUpdate:
+                    case Update.Update.UpdateResult.RunFailure:
+                        ErrorHandling.ErrorHandler.Handle(new ErrorHandling.UserFacingMessage("update-update-failed"), ErrorHandling.UserFacingErrorType.Toast, ErrorHandling.UserFacingSeverity.ShowError, ErrorHandling.LogLevel.Error);
+                        break;
+
+                    case Update.Update.UpdateResult.Georestricted:
+                        ErrorHandling.ErrorHandler.Handle(new ErrorHandling.UserFacingMessage("update-update-failed-georestricted"), ErrorHandling.UserFacingErrorType.Toast, ErrorHandling.UserFacingSeverity.ShowError, ErrorHandling.LogLevel.Error);
+                        break;
                 }
 
                 Application.Current.Dispatcher.Invoke(() =>

--- a/ui/src/UIUpdaters/VersionUpdater.cs
+++ b/ui/src/UIUpdaters/VersionUpdater.cs
@@ -111,18 +111,30 @@ namespace FirefoxPrivateNetwork.UIUpdaters
 
                                         var updateTask = Task.Run(async () =>
                                         {
-                                            var success = await Update.Update.Run(ProductConstants.GetNumericVersion());
-                                            if (success)
+                                            var updateResult = await Update.Update.Run(ProductConstants.GetNumericVersion());
+
+                                            switch (updateResult)
                                             {
-                                                // Dismiss the update toast
-                                                Application.Current.Dispatcher.Invoke(() =>
-                                                {
-                                                    Manager.MainWindowViewModel.UpdateToast.Toast_Dismiss(null, null);
-                                                });
-                                            }
-                                            else
-                                            {
-                                                ErrorHandling.ErrorHandler.Handle(new ErrorHandling.UserFacingMessage("update-update-failed"), ErrorHandling.UserFacingErrorType.Toast, ErrorHandling.UserFacingSeverity.ShowError, ErrorHandling.LogLevel.Error);
+                                                case Update.Update.UpdateResult.DisconnectTimeout:
+                                                case Update.Update.UpdateResult.GeneralFailure:
+                                                case Update.Update.UpdateResult.HttpError:
+                                                case Update.Update.UpdateResult.InvalidSignature:
+                                                case Update.Update.UpdateResult.SuccessNoUpdate:
+                                                case Update.Update.UpdateResult.RunFailure:
+                                                    ErrorHandling.ErrorHandler.Handle(new ErrorHandling.UserFacingMessage("update-update-failed"), ErrorHandling.UserFacingErrorType.Toast, ErrorHandling.UserFacingSeverity.ShowError, ErrorHandling.LogLevel.Error);
+                                                    break;
+
+                                                case Update.Update.UpdateResult.Georestricted:
+                                                    ErrorHandling.ErrorHandler.Handle(new ErrorHandling.UserFacingMessage("update-update-failed-georestricted"), ErrorHandling.UserFacingErrorType.Toast, ErrorHandling.UserFacingSeverity.ShowError, ErrorHandling.LogLevel.Error);
+                                                    break;
+
+                                                case Update.Update.UpdateResult.Success:
+                                                    // Dismiss the update toast
+                                                    Application.Current.Dispatcher.Invoke(() =>
+                                                    {
+                                                        Manager.MainWindowViewModel.UpdateToast.Toast_Dismiss(null, null);
+                                                    });
+                                                    break;
                                             }
                                         });
                                     },

--- a/ui/src/Update/UpdateHttpClient.cs
+++ b/ui/src/Update/UpdateHttpClient.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -16,7 +17,7 @@ namespace FirefoxPrivateNetwork.Update
     /// </summary>
     internal class UpdateHttpClient : IDisposable
     {
-        private readonly HttpClient httpClient;
+        private HttpClient httpClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UpdateHttpClient"/> class.
@@ -28,6 +29,15 @@ namespace FirefoxPrivateNetwork.Update
             {
                 MaxResponseContentBufferSize = maxDownloadSizeBytes,
             };
+
+            httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue
+            {
+                NoCache = true,
+                MustRevalidate = true,
+                NoStore = true,
+            };
+
+            httpClient.DefaultRequestHeaders.ConnectionClose = true;
         }
 
         /// <inheritdoc/>
@@ -46,6 +56,7 @@ namespace FirefoxPrivateNetwork.Update
         {
             HttpResponseMessage response = null;
 
+            // No caching
             for (var attempt = 0; attempt <= maxRetries; attempt++)
             {
                 try

--- a/ui/src/WCF/Service.cs
+++ b/ui/src/WCF/Service.cs
@@ -269,8 +269,8 @@ namespace FirefoxPrivateNetwork.WCF
         {
             try
             {
-                bool result = await Update.Update.Run(req.CurrentVersion);
-                return result ? new Response(200, "Success") : new Response(500, "Fail");
+                var result = await Update.Update.Run(req.CurrentVersion);
+                return result == Update.Update.UpdateResult.Success ? new Response(200, "Success") : new Response(500, "Fail");
             }
             catch (Exception ex)
             {

--- a/ui/src/WireGuard/Broker.cs
+++ b/ui/src/WireGuard/Broker.cs
@@ -18,6 +18,7 @@ namespace FirefoxPrivateNetwork.WireGuard
     internal class Broker
     {
         private const int ChildProcessTimeoutSeconds = 5;
+        private static Process brokerProcess;
 
         private IntPtr masterReadPipe = IntPtr.Zero;
         private IntPtr masterWritePipe = IntPtr.Zero;
@@ -36,7 +37,7 @@ namespace FirefoxPrivateNetwork.WireGuard
         /// <returns>True on success.</returns>
         public static bool UACShellExecute(string program, string arguments)
         {
-            var process = new Process()
+            brokerProcess = new Process()
             {
                 StartInfo =
                 {
@@ -48,7 +49,7 @@ namespace FirefoxPrivateNetwork.WireGuard
                 },
             };
 
-            return process.Start();
+            return brokerProcess.Start();
         }
 
         /// <summary>
@@ -345,6 +346,18 @@ namespace FirefoxPrivateNetwork.WireGuard
         public void ClearHeartbeat()
         {
             lastReceivedHeartBeat = DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// Shut down the broker.
+        /// </summary>
+        public void ShutDown()
+        {
+            if (brokerProcess != null)
+            {
+                brokerProcess.Kill();
+                brokerProcess.WaitForExit();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed issue where MSI upgrade would trigger a restart, added error message displaying a clear reason why the update failed when the cause is georestrictions, removed caching within the updater httpClient.