### PR TITLE
test: Create customized logger to log warnings and errors on committed files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,20 @@ jobs:
           command: |               
             .\tunnel\build.cmd
       - run: 
+          name: Build Logger
+          command: |
+            cd test/logger
+            nuget install packages.config -OutputDirectory packages
+            C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe -target:library SALogger.cs -reference:.\packages\Microsoft.Build.Utilities.Core.16.3.0\lib\net472\Microsoft.Build.Utilities.Core.dll,.\packages\Microsoft.Build.Framework.16.3.0\lib\net472\Microsoft.Build.Framework.dll,.\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll
+      - run: 
           name: Build Application
           command: |
+            New-Item -ItemType directory -Path test\result
             cd ui
             nuget restore -SolutionDirectory ./ 
-            MSBuild /t:Rebuild /p:Configuration=Release /p:Platform="x64" 
-            MSBuild /t:Rebuild /p:Configuration=Release /p:Platform="x86"
-            MSBuild /t:Rebuild /p:Configuration=Debug_QA /p:Platform="x64"
+            MSBuild -t:Rebuild -p:Configuration=Release -p:Platform="x64" -logger:"..\test\logger\SALogger.dll;..\test\result\Output.log"
+            MSBuild -t:Rebuild -p:Configuration=Release -p:Platform="x86"
+            MSBuild -t:Rebuild -p:Configuration=Debug_QA -p:Platform="x64"
       - run: 
           name: Build MSI
           command: |
@@ -56,19 +63,37 @@ jobs:
       - run:
           name: Generate Tests Report
           command: |
-            ui\packages\extent.0.0.3\tools\extent.exe -i test\result\unittests\result.xml -o test\result\unittests
-            .\ui\coverage.bat
-            New-Item -ItemType directory -Path test\result\integration-tests
-            cd test
-            go get -u github.com/jstemmer/go-junit-report
-            Get-Content -Path test.out | C:\Users\circleci\go\bin\go-junit-report > ./result/integration-tests/report.xml
-            cd result\integration-tests
-            Get-Content report.xml | Set-Content -Encoding utf8 report-utf8.xml
-            Remove-Item report.xml
-            npm config set unsafe-perm true
-            npm i -g xunit-viewer@5.1.11
-            xunit-viewer --results=report-utf8.xml --output=report.html
-            Copy-Item "C:\Users\circleci\AppData\Local\Mozilla\FirefoxPrivateNetworkVPN\log.bin" -Destination "..\"
+            If ([System.IO.File]::Exists("test\result\unittests\result.xml")) {
+              # unit test report
+              ui\packages\extent.0.0.3\tools\extent.exe -i test\result\unittests\result.xml -o test\result\unittests;
+              # code coverage report
+              .\ui\coverage.bat
+            }
+            # integration test report
+            If ([System.IO.File]::Exists("test\test.out")) {
+              New-Item -ItemType directory -Path test\result\integration-tests;
+              cd test;
+              go get -u github.com/jstemmer/go-junit-report;
+              Get-Content -Path test.out | C:\Users\circleci\go\bin\go-junit-report > ./result/integration-tests/report.xml;
+              cd result\integration-tests;
+              Get-Content report.xml | Set-Content -Encoding utf8 report-utf8.xml;
+              Remove-Item report.xml;
+              npm config set unsafe-perm true;
+              npm i -g xunit-viewer@5.1.11;
+              xunit-viewer --results=report-utf8.xml --output=report.html;
+            }
+            # save application log
+            If ([System.IO.File]::Exists("C:\Users\circleci\AppData\Local\Mozilla\FirefoxPrivateNetworkVPN\log.bin")) {
+              cd C:\Users\circleci\project\test\ringloggerParser
+              MSBuild -t:Rebuild -p:Configuration=Release
+              .\bin\Release\RingloggerParser.exe C:\Users\circleci\AppData\Local\Mozilla\FirefoxPrivateNetworkVPN\log.bin C:\Users\circleci\project\test\result\log.txt
+            }
+            # add comments to PR if there are any warnings or errors on committed files
+            If ([System.IO.File]::Exists("C:\Users\circleci\project\test\result\Output.log")) {
+              cd C:\Users\circleci\project\test\comment
+              npm i
+              node index.js
+            }
           when: always
       - run:
           name: Deploy

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ wireguard.server.base64.config
 
 #vim
 *.swp
+
+#logger
+test/logger/packages
+
+#comment
+test/comment/node_modules

--- a/test/comment/index.js
+++ b/test/comment/index.js
@@ -1,0 +1,15 @@
+const bot = require("circle-github-bot").create();
+const fs = require('fs');
+
+const path = '../result/Output.log'
+fs.readFile(path, (err, data) => {
+    if (err) {
+        console.log(`Fail to read file: ${path}, err: ${err.message}`)
+    }
+    const regex = /(?<errors>\d*) Error\(s\), (?<warnings>\d*) Warning\(s\)/gm;
+    const { errors, warnings } = regex.exec(data.toString()).groups
+    bot.comment(process.env.GH_AUTH_TOKEN, `<h3>Errors: ${errors}, Warnings: ${warnings}</h3>
+    Details: <strong>${bot.artifactLink('test/result/Output.log', 'details')}</strong>
+    `);
+})
+

--- a/test/comment/package-lock.json
+++ b/test/comment/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "circle-github-bot": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/circle-github-bot/-/circle-github-bot-2.0.1.tgz",
+      "integrity": "sha512-uTEX8RIjUVdvtILxEG3AXI2G9X0wZYrN/Y67IIvrosjM/nt/QBdogpDXbkVsNQmhmQYqqFguWUgt50z6UMIoXw=="
+    }
+  }
+}

--- a/test/comment/package.json
+++ b/test/comment/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "comment",
+  "version": "1.0.0",
+  "description": "",
+  "main": "comment.js",
+  "dependencies": {
+    "circle-github-bot": "^2.0.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/logger/SALogger.cs
+++ b/test/logger/SALogger.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Management.Automation;
+using System.Security;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace SALogger
+{
+    // This logger will derive from the Microsoft.Build.Utilities.Logger class.
+    public class SALogger : Logger
+    {
+        /// <summary>
+        /// Initialize is guaranteed to be called by MSBuild at the start of the build
+        /// before any events are raised.
+        /// </summary>
+        public override void Initialize(IEventSource eventSource)
+        {
+            // The name of the log file should be passed as the first item in the
+            // "parameters" specification in the /logger switch.  It is required
+            // to pass a log file to this logger. Other loggers may have zero or more than 
+            // one parameters.
+            if (null == Parameters)
+            {
+                throw new LoggerException("Log file was not set.");
+            }
+            string[] parameters = Parameters.Split(';');
+
+            string logFile = parameters[0];
+            if (String.IsNullOrEmpty(logFile))
+            {
+                throw new LoggerException("Log file was not set.");
+            }
+
+            if (parameters.Length > 1)
+            {
+                throw new LoggerException("Too many parameters passed.");
+            }
+
+            try
+            {
+                // Open the file
+                this.streamWriter = new StreamWriter(logFile);
+            }
+            catch (Exception ex)
+            {
+                if
+                (
+                    ex is UnauthorizedAccessException
+                    || ex is ArgumentNullException
+                    || ex is PathTooLongException
+                    || ex is DirectoryNotFoundException
+                    || ex is NotSupportedException
+                    || ex is ArgumentException
+                    || ex is SecurityException
+                    || ex is IOException
+                )
+                {
+                    throw new LoggerException("Failed to create log file: " + ex.Message);
+                }
+                else
+                {
+                    // Unexpected failure
+                    throw;
+                }
+            }
+            // Get the files that had changes in the last commit 
+            GetLastCommitChanges();
+            // For brevity, we'll only register for certain event types. Loggers can also
+            // register to handle TargetStarted/Finished and other events.
+            eventSource.WarningRaised += new BuildWarningEventHandler(eventSource_WarningRaised);
+            eventSource.ErrorRaised += new BuildErrorEventHandler(eventSource_ErrorRaised);
+        }
+
+        void eventSource_ErrorRaised(object sender, BuildErrorEventArgs e)
+        {
+            // BuildErrorEventArgs adds LineNumber, ColumnNumber, File, amongst other parameters
+            this.numOfErrors++;
+            string line = String.Format(": ERROR {0}({1},{2}): ", e.File, e.LineNumber, e.ColumnNumber);
+            WriteLineWithSenderAndMessage(line, e);
+        }
+
+        void eventSource_WarningRaised(object sender, BuildWarningEventArgs e)
+        {
+            foreach(PSObject file in this.results)
+            {
+                string lastCommitFile = file.ToString().Replace("/", @"\");
+
+                if(lastCommitFile.Contains(e.File))
+                {
+                    // BuildWarningEventArgs adds LineNumber, ColumnNumber, File, amongst other parameters
+                    this.numOfWarnings++;
+                    string line = String.Format(": Warning {0}({1},{2}): ", e.File, e.LineNumber, e.ColumnNumber);
+                    WriteLineWithSenderAndMessage(line, e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write a line to the log, adding the SenderName and Message
+        /// (these parameters are on all MSBuild event argument objects)
+        /// </summary>
+        private void WriteLineWithSenderAndMessage(string line, BuildEventArgs e)
+        {
+            WriteLine(e.SenderName + ": " + line, e);
+        }
+
+        /// <summary>
+        /// Just write a line to the log
+        /// </summary>
+        private void WriteLine(string line, BuildEventArgs e)
+        {
+            streamWriter.WriteLine(line + e.Message);
+        }
+
+        /// <summary>
+        /// Get a list of changed files' names from last commit.
+        /// </summary>
+        private void GetLastCommitChanges()
+        {
+            using (PowerShell powerShell = PowerShell.Create())
+            {
+                powerShell.AddScript("cd ..");
+                powerShell.AddScript(@"git diff-tree --no-commit-id --name-only -r HEAD");
+                results = powerShell.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Shutdown() is guaranteed to be called by MSBuild at the end of the build, after all 
+        /// events have been raised.
+        /// </summary>
+        public override void Shutdown()
+        {
+            // Done logging, let go of the file
+            streamWriter.WriteLine(this.numOfErrors + " Error(s), " + this.numOfWarnings + " Warning(s)");
+            streamWriter.Close();
+        }
+
+        private StreamWriter streamWriter;
+        private Collection<PSObject> results;
+        private int numOfWarnings = 0;
+        private int numOfErrors = 0;
+    }
+}

--- a/test/logger/packages.config
+++ b/test/logger/packages.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Build.Utilities.Core" version="16.3.0" targetFramework="net472" />
+  <package id="Microsoft.Build.Framework" version="16.3.0" targetFramework="net472" />
+  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0"/>
+</packages>

--- a/test/ringloggerParser/App.config
+++ b/test/ringloggerParser/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    </startup>
+</configuration>

--- a/test/ringloggerParser/Properties/AssemblyInfo.cs
+++ b/test/ringloggerParser/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RingloggerParser")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RingloggerParser")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f12db613-6ee9-46f0-aeee-d8aa701c5acd")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/ringloggerParser/Ringlogger.cs
+++ b/test/ringloggerParser/Ringlogger.cs
@@ -1,0 +1,209 @@
+﻿/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (C) 2019 Edge Security LLC. All Rights Reserved.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace RingloggerParser
+{
+    /// <summary>
+    /// Ringlogger allows logging to a memory mapped file.
+    /// </summary>
+    public class Ringlogger
+    {
+        private readonly Log log;
+        private readonly string tag;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ringlogger"/> class.
+        /// Used for logging to a binary log file.
+        /// </summary>
+        /// <param name="filename">Filename to log to.</param>
+        /// <param name="tag">Tag to use when logging (e.g. "[FPN]").</param>
+        public Ringlogger(string filename, string tag)
+        {
+            // Attempt to create a directory in the appdata folder if it does not exist
+            Directory.CreateDirectory(new FileInfo(filename).Directory.FullName);
+
+            var file = File.Open(filename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete);
+            file.SetLength(Log.Bytes);
+
+            using (var mmap = MemoryMappedFile.CreateFromFile(file, null, 0, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, false))
+            {
+                var view = mmap.CreateViewAccessor(0, Log.Bytes, MemoryMappedFileAccess.ReadWrite);
+
+                log = new Log(view);
+                if (log.Magic != log.ExpectedMagic)
+                {
+                    log.Clear();
+                    log.Magic = log.ExpectedMagic;
+                }
+            }
+
+            this.tag = tag;
+        }
+
+        /// <summary>
+        /// Exports a ringlogger file to an instantiated TextWriter object for later writing to a file.
+        /// </summary>
+        /// <param name="writer">An instantiated TextWriter object to be used for writing.</param>
+        public void WriteTo(TextWriter writer)
+        {
+            var start = log.NextIndex;
+            for (uint i = 0; i < log.LineCount; ++i)
+            {
+                var entry = log[i + start];
+                if (entry.Timestamp.IsEmpty)
+                {
+                    continue;
+                }
+
+                var text = entry.ToString();
+                if (text == null)
+                {
+                    continue;
+                }
+
+                writer.WriteLine(text);
+            }
+        }
+
+        private struct UnixTimestamp
+        {
+            public UnixTimestamp(long nanoSeconds)
+            {
+                Nanoseconds = nanoSeconds;
+            }
+
+            public bool IsEmpty => Nanoseconds == 0;
+
+            public long Nanoseconds { get; }
+
+            public override string ToString()
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(Nanoseconds / 1000000000).LocalDateTime.ToString("yyyy'-'MM'-'dd HH':'mm':'ss'.'") + ((Nanoseconds % 1000000000).ToString() + "00000").Substring(0, 6);
+            }
+        }
+
+        private struct Line
+        {
+            private const int MaxLineLength = 512;
+            private const int OffsetTimeNs = 0;
+            private const int OffsetLine = 8;
+
+            private readonly MemoryMappedViewAccessor view;
+            private readonly int start;
+
+            public Line(MemoryMappedViewAccessor viewAccessor, uint index)
+            {
+                (view, start) = (viewAccessor, (int)(Log.HeaderBytes + (index * Bytes)));
+            }
+
+            public static int Bytes => MaxLineLength + OffsetLine;
+
+            public UnixTimestamp Timestamp
+            {
+                get => new UnixTimestamp(view.ReadInt64(start + OffsetTimeNs));
+                set => view.Write(start + OffsetTimeNs, value.Nanoseconds);
+            }
+
+            public string Text
+            {
+                get
+                {
+                    var textBytes = new byte[MaxLineLength];
+
+                    view.ReadArray(start + OffsetLine, textBytes, 0, textBytes.Length);
+                    int nullByte = Array.IndexOf<byte>(textBytes, 0);
+
+                    if (nullByte <= 0)
+                    {
+                        return null;
+                    }
+
+                    return Encoding.UTF8.GetString(textBytes, 0, nullByte);
+                }
+
+                set
+                {
+                    if (value == null)
+                    {
+                        view.WriteArray(start + OffsetLine, new byte[MaxLineLength], 0, MaxLineLength);
+                        return;
+                    }
+
+                    var textBytes = Encoding.UTF8.GetBytes(value);
+                    var bytesToWrite = Math.Min(MaxLineLength - 1, textBytes.Length);
+
+                    view.Write(start + OffsetLine + bytesToWrite, (byte)0);
+                    view.WriteArray(start + OffsetLine, textBytes, 0, bytesToWrite);
+                }
+            }
+
+            public override string ToString()
+            {
+                var time = Timestamp;
+                if (time.IsEmpty)
+                {
+                    return null;
+                }
+
+                var text = Text;
+                if (text == null)
+                {
+                    return null;
+                }
+
+                return string.Format("{0}: {1}", time, text);
+            }
+        }
+
+        private struct Log
+        {
+            private const uint MaxLines = 2048;
+            private const uint MagicNumber = 0xbadbabe;
+
+            private const int OffsetMagic = 0;
+            private const int OffsetNextIndex = 4;
+            private const int OffsetLines = 8;
+
+            private readonly MemoryMappedViewAccessor view;
+
+            public Log(MemoryMappedViewAccessor view)
+            {
+                this.view = view;
+            }
+
+            public static int HeaderBytes => OffsetLines;
+
+            public static int Bytes => (int)(HeaderBytes + (Line.Bytes * MaxLines));
+
+            public uint ExpectedMagic => MagicNumber;
+
+            public uint Magic
+            {
+                get => view.ReadUInt32(OffsetMagic);
+                set => view.Write(OffsetMagic, value);
+            }
+
+            public uint NextIndex
+            {
+                get => view.ReadUInt32(OffsetNextIndex);
+                set => view.Write(OffsetNextIndex, value);
+            }
+
+            public uint LineCount => MaxLines;
+
+            public Line this[uint i] => new Line(view, i % MaxLines);
+
+            public void Clear() => view.WriteArray(0, new byte[Bytes], 0, Bytes);
+        }
+    }
+}

--- a/test/ringloggerParser/RingloggerParser.cs
+++ b/test/ringloggerParser/RingloggerParser.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RingloggerParser
+{
+    class RingloggerParser
+    {
+        static void Main(string[] args)
+        {
+            // Test if input arguments were supplied.
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Please enter input file and output file");
+                Console.WriteLine("Usage: RingloggerParser.exe <input> <output>");
+                return;
+            }
+            var logTxt = File.CreateText(args[1]);
+            Ringlogger Ringlogger = new Ringlogger(args[0], "FPN");
+            Ringlogger.WriteTo(logTxt);
+            logTxt.Close();
+        }
+    }
+}

--- a/test/ringloggerParser/RingloggerParser.csproj
+++ b/test/ringloggerParser/RingloggerParser.csproj
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F12DB613-6EE9-46F0-AEEE-D8AA701C5ACD}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>RingloggerParser</RootNamespace>
+    <AssemblyName>RingloggerParser</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RingloggerParser.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Ringlogger.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/test/ringloggerParser/RingloggerParser.csproj.user
+++ b/test/ringloggerParser/RingloggerParser.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectView>ProjectFiles</ProjectView>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
As we are using StyleCop Anyalyzer to lint C# code, we want to show warnings and errors in the last committed files for every PR request. We create a customized logger "SALogger" to log warnings and errors in last committed files instead of all files in the whole project. After we get the logs, we send it back to PR as comments. Meanwhile, we added a RingloggerParser to parse log file (log.bin) to txt format which can be readable.