### PR TITLE
ui: Add hand cursor to VPN toggle hover state.

### DIFF
--- a/ui/src/UI/Components/VPNToggle/VPNToggle.xaml
+++ b/ui/src/UI/Components/VPNToggle/VPNToggle.xaml
@@ -96,6 +96,9 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="BorderBrush" Value="{StaticResource 'Grey/Grey 10'}" />
                         </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Cursor" Value="Hand" />
+                        </Trigger>
                     </Style.Triggers>
                 </Style>
             </Border.Style>


### PR DESCRIPTION
Add hand cursor to VPN toggle hover state to be consistent with Windows design standards.  The mouse pointer should provide a visual indicator when moused over a focusable element.