### PR TITLE
ui: Add captive portal detection feature

### DIFF
--- a/ui/src/Manager.cs
+++ b/ui/src/Manager.cs
@@ -69,6 +69,11 @@ namespace FirefoxPrivateNetwork
         public static Network.WlanWatcher WlanWatcher { get; set; }
 
         /// <summary>
+        /// Gets or sets the captive portal detector.
+        /// </summary>
+        public static Network.CaptivePortalDetection CaptivePortalDetector { get; set; }
+
+        /// <summary>
         /// Gets or sets the network pinger.
         /// </summary>
         public static Network.Pinger PingManager { get; set; }
@@ -107,6 +112,7 @@ namespace FirefoxPrivateNetwork
             InitializeTranslationService();
             InitializeUIUpdaters();
             InitializeWlanWatcher();
+            InitializeCaptivePortalDetector();
         }
 
         /// <summary>
@@ -173,6 +179,14 @@ namespace FirefoxPrivateNetwork
         public static void InitializeWlanWatcher()
         {
             WlanWatcher = new Network.WlanWatcher();
+        }
+
+        /// <summary>
+        /// Initialize the captive portal detector.
+        /// </summary>
+        public static void InitializeCaptivePortalDetector()
+        {
+            CaptivePortalDetector = new Network.CaptivePortalDetection();
         }
 
         /// <summary>

--- a/ui/src/Network/CaptivePortalDetection.cs
+++ b/ui/src/Network/CaptivePortalDetection.cs
@@ -1,20 +1,107 @@
-﻿/* SPDX-License-Identifier: MIT
+﻿// <copyright file="CaptivePortalDetection.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+/* SPDX-License-Identifier: MIT
  *
  * Copyright (C) 2019 Edge Security LLC. All Rights Reserved.
  */
 
+using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 namespace FirefoxPrivateNetwork.Network
 {
+    /// <summary>
+    /// Used for detecting connectivity issues due to captive portals.
+    /// </summary>
     public class CaptivePortalDetection
     {
-        public enum ConnectivityStatus {
-            NoConnectivity = -1,
-            CaptivePortalDetected = 0,
-            HaveConnectivity = 1
+        private bool captivePortalDetected = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CaptivePortalDetection"/> class.
+        /// </summary>
+        public CaptivePortalDetection()
+        {
+            // Add an event handler to reset the captive portal detection check when a network change is detected
+            NetworkChange.NetworkAddressChanged += new NetworkAddressChangedEventHandler((sender, e) =>
+            {
+                Task.Delay(System.TimeSpan.FromSeconds(5)).ContinueWith(task => { CaptivePortalDetected = false; });
+            });
         }
-        [DllImport("tunnel.dll", EntryPoint = "TestConnectivity", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ConnectivityStatus TestConnectivity();
+
+        /// <summary>
+        /// Connectivity status result when checking for connectivity/captive portal presense.
+        /// </summary>
+        public enum ConnectivityStatus
+        {
+            /// <summary>
+            /// There is no internet connectivity available at this time.
+            /// </summary>
+            NoConnectivity = -1,
+
+            /// <summary>
+            /// Potential internet connectivity, as a captive portal has been detected.
+            /// </summary>
+            CaptivePortalDetected,
+
+            /// <summary>
+            /// There is internet connectivity available.
+            /// </summary>
+            HaveConnectivity,
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether we have detected a captive portal network.
+        /// </summary>
+        public bool CaptivePortalDetected
+        {
+            get
+            {
+                return captivePortalDetected;
+            }
+
+            set
+            {
+                captivePortalDetected = value;
+                if (value)
+                {
+                    // Send a windows notification if captive portal is detected.
+                    Manager.TrayIcon.ShowNotification(
+                        Manager.TranslationService.GetString("windows-notification-captive-portal-title"),
+                        Manager.TranslationService.GetString("windows-notification-captive-portal-content"),
+                        NotificationArea.ToastIconType.Disconnected
+                    );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds a route to specified IP and tries to retrieve a URL from a host, then checks downloaded contents of file with expectedTestResult.
+        /// This will check whether there is any connectivity outside of the confines of a potentially active WireGuard tunnel.
+        /// </summary>
+        /// <param name="ip">IP address to add to routing table (to route traffic outside of the tunnel).</param>
+        /// <param name="host">Host to contact for captive portal detection.</param>
+        /// <param name="url">URL to download.</param>
+        /// <param name="expectedTestResult">Expected contents of the downloaded file (e.g. "success").</param>
+        /// <returns>Returns connectivity status indicating current connection state.</returns>
+        [DllImport("tunnel.dll", EntryPoint = "TestOutsideConnectivity", CallingConvention = CallingConvention.Cdecl)]
+        public static extern ConnectivityStatus TestOutsideConnectivity([MarshalAs(UnmanagedType.LPWStr)] string ip, [MarshalAs(UnmanagedType.LPWStr)] string host, [MarshalAs(UnmanagedType.LPWStr)] string url, [MarshalAs(UnmanagedType.LPWStr)] string expectedTestResult);
+
+        /// <summary>
+        /// Checks whether we are located on a captive portal network.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation which returns a ConnectivityStatus value.</returns>
+        public static Task<ConnectivityStatus> IsCaptivePortalActiveTask()
+        {
+            var testOutsideConnectivityTask = Task.Run(() =>
+            {
+                return TestOutsideConnectivity(ProductConstants.CaptivePortalDetectionIP, ProductConstants.CaptivePortalDetectionHost, ProductConstants.CaptivePortalDetectionUrl, ProductConstants.CaptivePortalDetectionValidReplyContents);
+            });
+
+            return testOutsideConnectivityTask;
+        }
     }
 }

--- a/ui/src/Network/WlanWatcher.cs
+++ b/ui/src/Network/WlanWatcher.cs
@@ -109,7 +109,7 @@ namespace FirefoxPrivateNetwork.Network
                         }
                         else
                         {
-                            if ((DateTime.UtcNow - accessPoints[bSsid].LastNotified).TotalSeconds < ProductConstants.InsecureWiFiTimeout)
+                            if ((DateTime.UtcNow - accessPoints[bSsid].LastNotified).TotalSeconds < ProductConstants.UnsecureWiFiTimeout)
                             {
                                 showNotification = false;
                             }

--- a/ui/src/ProductConstants.cs
+++ b/ui/src/ProductConstants.cs
@@ -141,7 +141,27 @@ namespace FirefoxPrivateNetwork
         /// <summary>
         /// Number of seconds to wait before displaying another "insecure network detected" toast popup upon connecting to an unsecured WiFi network.
         /// </summary>
-        public static readonly int InsecureWiFiTimeout = 20;
+        public static readonly int UnsecureWiFiTimeout = 20;
+
+        /// <summary>
+        /// IP address housing the captive portal detection TXT file.
+        /// </summary>
+        public static readonly string CaptivePortalDetectionIP = "184.150.160.34";
+
+        /// <summary>
+        /// Hostname to use when contacting CaptivePortalDetectionIP for captive portal detection.
+        /// </summary>
+        public static readonly string CaptivePortalDetectionHost = "detectportal.firefox.com";
+
+        /// <summary>
+        /// Full URL to attempt to download during the captive portal detection process. %s will be replaced with CaptivePortalDetectionHost.
+        /// </summary>
+        public static readonly string CaptivePortalDetectionUrl = "http://%s/success.txt";
+
+        /// <summary>
+        /// Contents of the TXT file downloaded when checking against a captive portal being active.
+        /// </summary>
+        public static readonly string CaptivePortalDetectionValidReplyContents = "success";
 
         /// <summary>
         /// Gets or sets a value indicating whether developer mode is on. Developer mode is on when the default FxA base URL has been overridden.

--- a/ui/src/UIUpdaters/ConnectionStatusUpdater.cs
+++ b/ui/src/UIUpdaters/ConnectionStatusUpdater.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using FirefoxPrivateNetwork.WireGuard;
 
 namespace FirefoxPrivateNetwork.UIUpdaters
 {
@@ -154,6 +155,18 @@ namespace FirefoxPrivateNetwork.UIUpdaters
             {
                 Manager.TrayIcon.SetDisconnected();
                 return;
+            }
+
+            // Make sure to try and detect captive portals if unstable/no signal
+            if (stability == Models.ConnectionStability.NoSignal || stability == Models.ConnectionStability.Unstable)
+            {
+                // Attempt to check for a captive portal if the settings option is enabled and captive portal has not already been detected for the current network address
+                if (Manager.Settings.Network.CaptivePortalAlert && !Manager.CaptivePortalDetector.CaptivePortalDetected)
+                {
+                    var ipcDetectCaptivePortalMsg = new IPCMessage(IPCCommand.IpcDetectCaptivePortal);
+                    var brokerIPC = Manager.Broker.GetBrokerIPC();
+                    brokerIPC.WriteToPipe(ipcDetectCaptivePortalMsg);
+                }
             }
 
             if (stability == Models.ConnectionStability.NoSignal)

--- a/ui/src/WireGuard/IPC/IPCCommand.cs
+++ b/ui/src/WireGuard/IPC/IPCCommand.cs
@@ -34,6 +34,16 @@ namespace FirefoxPrivateNetwork.WireGuard
         public const string IpcDisconnect = "ipcdisconnect=1";
 
         /// <summary>
+        /// Captive portal detection request.
+        /// </summary>
+        public const string IpcDetectCaptivePortal = "ipcdetectcaptiveportal=1";
+
+        /// <summary>
+        /// Captive portal detection reply.
+        /// </summary>
+        public const string IpcDetectCaptivePortalReply = "ipcdetectcaptiveportalreply=1";
+
+        /// <summary>
         /// Process ID reply command.
         /// </summary>
         public const string IpcPidReply = "ipcpid=1";


### PR DESCRIPTION
This feature is a settings option for a Windows notification when
connectivity issues due to a captive portal is detected. Detection of a
captive portal is determined by adding a route and sending a GET request
to a specified IP address by calling
`CaptivePortalDetection.TestOutsideConnectivity` from the broker
process. When a captive portal is detected, a Windows notification will
be displayed, prompting the user to turn off their VPN and enter login
credentials for the captive portal before re-enabling their VPN.