### PR TITLE
ui: Bring window to front when login authentication is complete

### DIFF
--- a/ui/src/FxA/Login.cs
+++ b/ui/src/FxA/Login.cs
@@ -210,6 +210,9 @@ namespace FirefoxPrivateNetwork.FxA
                                 }
                             }
 
+                            ((UI.MainWindow)owner).Show();
+                            ((UI.MainWindow)owner).Topmost = true;
+                            ((UI.MainWindow)owner).WindowState = WindowState.Normal;
                             ((UI.MainWindow)owner).Activate();
                         }
                     });


### PR DESCRIPTION
Upon login authentication, the client will bring the main window to the
front automatically, allowing the user to continue with the post-login
flow.