### PR TITLE
ui: Add minimum visual delays for connection transition states

### DIFF
--- a/ui/src/ViewModels/MainWindowViewModel.cs
+++ b/ui/src/ViewModels/MainWindowViewModel.cs
@@ -129,6 +129,7 @@ namespace FirefoxPrivateNetwork.ViewModels
                         }
                         else
                         {
+                            Manager.ConnectionStatusUpdater.StartConnectionTransitionStopwatch();
                             tunnelStatus = value;
                         }
 
@@ -141,6 +142,7 @@ namespace FirefoxPrivateNetwork.ViewModels
                         }
                         else
                         {
+                            Manager.ConnectionStatusUpdater.StartConnectionTransitionStopwatch();
                             tunnelStatus = value;
                         }
 

--- a/ui/src/WireGuard/Connector.cs
+++ b/ui/src/WireGuard/Connector.cs
@@ -33,6 +33,7 @@ namespace FirefoxPrivateNetwork.WireGuard
                 Manager.MainWindowViewModel.IsServerSwitching = true;
                 Manager.MainWindowViewModel.SwitchingServerFrom = previousServerCity;
                 Manager.MainWindowViewModel.SwitchingServerTo = switchServerCity;
+                Manager.ConnectionStatusUpdater.StartConnectionTransitionStopwatch();
 
                 new Thread(() =>
                 {


### PR DESCRIPTION
For connection transition states (connecting, disconnecting, switching),
there will be a minimum UI delay (1s, 1s, 1.5s respectively) before
changing to non-transition states (unprotected, protected).