### PR TITLE
test: set up AWS ec2 to do smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,78 @@ jobs:
           path: test/result
       - store_artifacts:
           path: test/result
+      - persist_to_workspace:
+          root: ~/project/test
+          paths: .
+  smoke-test:
+    executor:
+      name: win/vs2019
+      shell: powershell.exe
+    environment:
+      GO111MODULE: "on"
+    steps:
+      - attach_workspace:
+          at: ~/project/test
+      - run: 
+          name: Install AWSTool
+          command: |
+            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+            Install-Module -Name AWS.Tools.S3,AWS.Tools.CloudFormation,AWS.Tools.EC2 -Scope AllUsers -Force
+      - run:
+          name: Upload To S3
+          command: |
+            $ProgressPreference = "SilentlyContinue"
+            Write-S3Object -BucketName $env:S3_BUCKET -File test/result/FirefoxPrivateNetworkVPN.msi -Key msi/$env:CIRCLE_BUILD_NUM/FirefoxPrivateNetworkVPN.msi
+      - run: 
+          name: Launch EC2 Win10
+          command: |
+            ./test/smoke/aws/create_ec2.ps1
+      - run: 
+          name: Wait for Smoke Test result
+          command: |
+            New-Item -Path ./test/result/ -Name "smoketest" -ItemType "directory"
+            $timeout = new-timespan -Minutes 20
+            $sw = [diagnostics.stopwatch]::StartNew()
+            while ($sw.elapsed -lt $timeout){
+              If(Test-S3Bucket -BucketName $env:S3_BUCKET) {
+                If(Get-S3Object -BucketName $env:S3_BUCKET -Key smoke/$env:CIRCLE_BUILD_NUM/smoke_test_result.txt) { ## verify if exist
+                  $ProgressPreference = "SilentlyContinue"
+                  Read-S3Object -BucketName $env:S3_BUCKET -Key smoke/$env:CIRCLE_BUILD_NUM/smoke_test_result.txt -File test/result/smoketest/smoke_test_result.txt
+                  If ([System.IO.File]::Exists("C:\Users\circleci\project\test\result\smoketest\smoke_test_result.txt")) {
+                    break
+                  }
+                }
+                Else {
+                  Write-Host "The smoke test result is not available!"
+                } 
+              } 
+              Else {
+                Write-Host "The bucket $env:S3_BUCKET does not exist."
+                Exit 1
+              }
+              start-sleep -seconds 10
+            }
+            If (![System.IO.File]::Exists("C:\Users\circleci\project\test\result\smoketest\smoke_test_result.txt")) {
+              Write-Host "Could not find smoke test result!"
+              Exit 1
+            } Else {
+              $log = Get-Content -Path C:\Users\circleci\project\test\result\smoketest\smoke_test_result.txt
+              $log
+              $failed = $log -match 'Failed:\s{1}\d{1}'
+              If($failed) {
+                Write-Host 'Smoke Tests Failed!'
+                exit 1
+              }
+            }
+      - run:
+          name: Clean Up
+          command: |
+            ./test/smoke/aws/terminate_ec2.ps1
+          when: always
+      - store_test_results:
+          path: test/result
+      - store_artifacts:
+          path: test/result
 workflows:
   nightly:
     triggers:
@@ -118,4 +190,17 @@ workflows:
   workflow:
     jobs:
       - build
+  smoke-test:
+    triggers:
+      - schedule:
+          cron: "0 0,12 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build
+      - smoke-test:
+          requires:
+            - build
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ test/logger/packages
 
 #comment
 test/comment/node_modules
+
+#smoke test
+test/smoke/FirefoxPrivateVPNUITest/packages
+test/smoke/FirefoxPrivateVPNUITest/TestResult

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.sln
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29209.62
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FirefoxPrivateVPNUITest", "FirefoxPrivateVPNUITest\FirefoxPrivateVPNUITest.csproj", "{716E361C-5621-4CD1-915E-05A7AE769CB0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{716E361C-5621-4CD1-915E-05A7AE769CB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{716E361C-5621-4CD1-915E-05A7AE769CB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{716E361C-5621-4CD1-915E-05A7AE769CB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{716E361C-5621-4CD1-915E-05A7AE769CB0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CA49EBD9-5743-4043-A4E9-3D752BD77E6E}
+	EndGlobalSection
+EndGlobal

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/BrowserSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/BrowserSession.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace FirefoxPrivateVPNUITest
+{
+    public class BrowserSession: IDisposable
+    {
+        // Note: append /wd/hub to the URL if you're directing the test at Appium
+        private const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
+        private const string IEExplorerAppId = "Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge";
+
+        public WindowsDriver<WindowsElement> session { get; }
+
+        public BrowserSession()
+        {
+            if (session == null)
+            {
+                // Create a new session to bring up an instance of the FirefoxPrivateNetworkVPN application
+                DesiredCapabilities appCapabilities = new DesiredCapabilities();
+                appCapabilities.SetCapability("app", IEExplorerAppId);
+                session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+                Assert.IsNotNull(session);
+
+                // Set implicit timeout to 1.5 seconds to make element search to retry every 500 ms for at most three times
+                session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1.5);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Close the application and delete the session
+            if (session != null)
+            {
+                session.Close();
+                session.Quit();
+            }
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNSession.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace FirefoxPrivateVPNUITest
+{
+    public class FirefoxPrivateVPNSession: IDisposable
+    {
+        // Note: append /wd/hub to the URL if you're directing the test at Appium
+        private const string WindowsApplicationDriverUrl = "http://127.0.0.1:4723";
+        private const string FirefoxPrivateVPNAppId = @"C:\Program Files\Mozilla\Firefox Private Network VPN\FirefoxPrivateNetworkVPN.exe";
+
+        public WindowsDriver<WindowsElement> Session;
+
+        public FirefoxPrivateVPNSession()
+        {
+            if (Session == null)
+            {
+                // Create a new session to bring up an instance of the FirefoxPrivateNetworkVPN application
+                DesiredCapabilities appCapabilities = new DesiredCapabilities();
+                appCapabilities.SetCapability("app", FirefoxPrivateVPNAppId);
+                appCapabilities.SetCapability("deviceName", "WindowsPC");
+                Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+                Assert.IsNotNull(Session);
+
+                // Set implicit timeout to 1.5 seconds to make element search to retry every 500 ms for at most three times
+                Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1.5);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Close the application and delete the session
+            if (Session != null)
+            {
+                Session.Quit();
+                DesiredCapabilities appCapabilities = new DesiredCapabilities();
+                appCapabilities.SetCapability("app", "Root");
+                var desktopSession = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
+                desktopSession.FindElementByName("Notification Chevron").Click();
+                var clientTray = desktopSession.FindElementByName("Firefox Private Network VPN - Disconnected");
+                desktopSession.Mouse.ContextClick(clientTray.Coordinates);
+                desktopSession.FindElementByName("_Exit").Click();
+                desktopSession.Quit();
+                Session = null;
+            }
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.csproj
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{716E361C-5621-4CD1-915E-05A7AE769CB0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FirefoxPrivateVPNUITest</RootNamespace>
+    <AssemblyName>FirefoxPrivateVPNUITest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="appium-dotnet-driver, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WinAppDriver.Appium.WebDriver.1.0.1-Preview\lib\net45\appium-dotnet-driver.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="WebDriver, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.8.0\lib\net45\WebDriver.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver.Support, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.8.0\lib\net45\WebDriver.Support.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BrowserSession.cs" />
+    <Compile Include="FirefoxPrivateVPNSession.cs" />
+    <Compile Include="LandingScreen.cs" />
+    <Compile Include="LayoutScreen.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SignInScreen.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/LandingScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/LandingScreen.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium.Appium.Windows;
+
+namespace FirefoxPrivateVPNUITest
+{
+    [TestClass]
+    public class LandingScreen
+    {
+        private FirefoxPrivateVPNSession vpnClient;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            vpnClient = new FirefoxPrivateVPNSession();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            vpnClient.Dispose();
+        }
+
+        [TestMethod]
+        public void TestLandingScreen()
+        {
+            // Assert the texts
+            WindowsElement landingView = vpnClient.Session.FindElementByClassName("LandingView");
+            var titles = landingView.FindElementsByClassName("TextBlock");
+            Assert.IsTrue(titles.Count >= 2);
+            Assert.AreEqual("Firefox Private Network", titles[0].Text);
+            Assert.AreEqual("A fast, secure and easy to use VPN \r\n(Virtual Private Network).", titles[1].Text);
+            // Assert the Get started button
+            var getStartedButton = landingView.FindElementByName("Get started");
+            Assert.AreEqual("Get started", getStartedButton.Text);
+            // Assert the learn more hyperlink
+            var learnMoreHyperlink = landingView.FindElementByName("Learn more");
+            Assert.AreEqual("Learn more", learnMoreHyperlink.Text);
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/LayoutScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/LayoutScreen.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Windows;
+
+namespace FirefoxPrivateVPNUITest
+{
+    [TestClass]
+    public class LayoutScreen
+    {
+        private FirefoxPrivateVPNSession vpnClient;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            vpnClient = new FirefoxPrivateVPNSession();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            vpnClient.Dispose();
+        }
+        [TestMethod]
+        public void TestLayoutScreen()
+        {
+            // Test minimize
+            vpnClient.Session.Keyboard.SendKeys(Keys.Command + Keys.ArrowDown + Keys.Command);
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+            // Test maximize
+            vpnClient.Session.Keyboard.SendKeys(Keys.Command + Keys.ArrowUp + Keys.ArrowUp + Keys.Command);
+            Thread.Sleep(TimeSpan.FromSeconds(1));
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Properties/AssemblyInfo.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("FirefoxPrivateVPNUITest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FirefoxPrivateVPNUITest")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("716e361c-5621-4cd1-915e-05a7ae769cb0")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/SignInScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/SignInScreen.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Windows;
+
+namespace FirefoxPrivateVPNUITest
+{
+    [TestClass]
+    public class SignInScreen
+    {
+        private FirefoxPrivateVPNSession vpnClient;
+        private BrowserSession browser;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            vpnClient = new FirefoxPrivateVPNSession();
+            browser = new BrowserSession();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            vpnClient.Dispose();
+            browser.Dispose();
+        }
+
+        [TestMethod]
+        public void TestSignInFlow()
+        {
+
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/app.config
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/packages.config
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.3.1" targetFramework="net472" />
+  <package id="Microsoft.WinAppDriver.Appium.WebDriver" version="1.0.1-Preview" targetFramework="net472" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
+  <package id="Selenium.Support" version="3.8.0" targetFramework="net472" />
+  <package id="Selenium.WebDriver" version="3.8.0" targetFramework="net472" />
+</packages>

--- a/test/smoke/aws/create_ec2.ps1
+++ b/test/smoke/aws/create_ec2.ps1
@@ -1,0 +1,23 @@
+Set-DefaultAWSRegion -Region us-east-1
+# validate cloudformation template
+$content = Get-Content -Path .\test\smoke\aws\template.json -Raw
+Test-CFNTemplate -TemplateBody $content
+
+$p1 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="KeyName"; ParameterValue="$env:KEY_NAME"}
+$p2 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="S3BucketName"; ParameterValue="$env:S3_BUCKET"}
+$p3 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="ImageId"; ParameterValue="$env:IMAGE_ID"}
+$p4 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="BuildNumber"; ParameterValue="$env:CIRCLE_BUILD_NUM"}
+$p5 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="GitBranch"; ParameterValue="$env:CIRCLE_BRANCH"}
+$p6 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="GitPrivateKeyPart1"; ParameterValue="$env:GIT_PRIVATE_KEY_1"}
+$p7 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="GitPrivateKeyPart2"; ParameterValue="$env:GIT_PRIVATE_KEY_2"}
+$p8 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="GitPublicKey"; ParameterValue="$env:GIT_PUBLIC_KEY"}
+$p9 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="KeyValue"; ParameterValue="$env:KEY_VALUE"}
+
+$params = @($p1,$p2,$p3,$p4,$p5,$p6,$p7,$p8,$p9)
+
+$stack = "guardian-stack-$env:CIRCLE_BUILD_NUM"
+# create stack
+New-CFNStack -StackName $stack -TemplateBody $content -Capability CAPABILITY_IAM -Parameter $params
+
+# wait stack to complete
+Wait-CFNStack -StackName $stack -Timeout 300

--- a/test/smoke/aws/logon.ps1
+++ b/test/smoke/aws/logon.ps1
@@ -1,0 +1,27 @@
+$env:BUILD_NUMBER = [System.Environment]::GetEnvironmentVariable("BUILD_NUMBER","Machine") 
+$env:S3_BUCKET = [System.Environment]::GetEnvironmentVariable("S3_BUCKET","Machine") 
+New-Item -Path "~/" -Name "test" -ItemType "directory"
+If ([System.IO.File]::Exists("C:\Program Files (x86)\Windows Application Driver\WinAppDriver.exe")) {
+    Start-Process -FilePath "powershell" -ArgumentList "C:\'Program Files (x86)'\'Windows Application Driver'\WinAppDriver.exe"
+    
+    Start-Sleep -Seconds 15  
+}     
+
+$timeout = new-timespan -Minutes 10
+$sw = [diagnostics.stopwatch]::StartNew()
+while ($sw.elapsed -lt $timeout){
+
+    Start-Process -FilePath "powershell" -Wait -ArgumentList "C:\'Program Files (x86)'\'Microsoft Visual Studio'\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe C:\Users\Administrator\guardian-vpn-windows\test\smoke\FirefoxPrivateVPNUITest\FirefoxPrivateVPNUITest\bin\Release\FirefoxPrivateVPNUITest.dll | Out-File -FilePath ~/test/result.txt"
+
+    $log = Get-Content -Path ~/test/result.txt
+
+    If ($log -Match 'Total tests') {
+
+        Write-S3Object -BucketName $env:S3_BUCKET -Key smoke/$env:BUILD_NUMBER/smoke_test_result.txt -File ~/test/result.txt
+
+        Write-Host 'Complete'
+
+        break
+    }
+    start-sleep -seconds 10
+}

--- a/test/smoke/aws/template.json
+++ b/test/smoke/aws/template.json
@@ -1,0 +1,285 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "AWS CloudFormation Sample Template EC2InstanceWithSecurityGroupSample: Create an Amazon EC2 instance running the Amazon Linux AMI. The AMI is chosen based on the region in which the stack is run. This example creates an EC2 security group for the instance to give you SSH access. **WARNING** This template creates an Amazon EC2 instance. You will be billed for the AWS resources used if you create a stack from this template.",
+
+  "Parameters" : {
+    "KeyName": {
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instance",
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "ConstraintDescription" : "must be the name of an existing EC2 KeyPair."
+    },
+
+    "InstanceType" : {
+      "Description" : "WebServer EC2 instance type",
+      "Type" : "String",
+      "Default" : "t2.small",
+      "AllowedValues" : [ "t1.micro", "t2.nano", "t2.micro", "t2.small", "t2.medium", "t2.large", "m1.small", "m1.medium", "m1.large", "m1.xlarge", "m2.xlarge", "m2.2xlarge", "m2.4xlarge", "m3.medium", "m3.large", "m3.xlarge", "m3.2xlarge", "m4.large", "m4.xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "c1.medium", "c1.xlarge", "c3.large", "c3.xlarge", "c3.2xlarge", "c3.4xlarge", "c3.8xlarge", "c4.large", "c4.xlarge", "c4.2xlarge", "c4.4xlarge", "c4.8xlarge", "g2.2xlarge", "g2.8xlarge", "r3.large", "r3.xlarge", "r3.2xlarge", "r3.4xlarge", "r3.8xlarge", "i2.xlarge", "i2.2xlarge", "i2.4xlarge", "i2.8xlarge", "d2.xlarge", "d2.2xlarge", "d2.4xlarge", "d2.8xlarge", "hi1.4xlarge", "hs1.8xlarge", "cr1.8xlarge", "cc2.8xlarge", "cg1.4xlarge"],
+      "ConstraintDescription" : "must be a valid EC2 instance type."
+    },
+
+    "IPLocation" : {
+      "Description" : "The IP address range that can be used to RDP to the EC2 instances",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "0.0.0.0/0",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
+    "ImageId": {
+      "Description" : "AWS AMI Id",
+      "Type": "String"
+    },
+    "BuildNumber": {
+      "Description" : "CIRCLE_BUILD_NUM",
+      "Type": "String"
+    },
+    "S3BucketName": {
+      "Description" : "S3 Bucket Name",
+      "Type": "String"
+    },
+    "GitBranch": {
+      "Description" : "Github Branch",
+      "Type": "String"
+        },
+    "GitPrivateKeyPart1": {
+      "Description" : "Github Private Key part 1",
+      "Type": "String"
+    },
+    "GitPrivateKeyPart2": {
+      "Description" : "Github Private Key part 2",
+      "Type": "String"
+    },
+    "GitPublicKey": {
+      "Description" : "Github Public Key",
+      "Type": "String"
+    },
+    "KeyValue": {
+      "Description" : "key value",
+      "Type": "String"
+    }
+  },
+
+  "Resources" : {
+    "EC2Instance" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "InstanceType" : { "Ref" : "InstanceType" },
+        "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
+        "KeyName" : { "Ref" : "KeyName" },
+        "ImageId" : { "Ref" : "ImageId" },
+        "IamInstanceProfile" : {
+          "Ref" : "ReadWriteS3BucketsInstanceProfile"
+        },
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "<powershell>\n",
+                "Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False \n",
+                "New-ItemProperty -Path \"HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\" -Name DisableAntiSpyware -Value 1 -PropertyType DWORD -Force \n",             
+
+                "$AutoUpdate = (New-Object -com \"Microsoft.Update.AutoUpdate\").Settings \n",
+                "$AutoUpdate.NotificationLevel = 1 \n",
+                "$AutoUpdate.Save() \n",
+                "Write-Host \"Windows Update has been disabled.\" -ForegroundColor Green \n",
+                
+                "[Environment]::SetEnvironmentVariable('BUILD_NUMBER', '",
+                {
+                  "Ref": "BuildNumber"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "[Environment]::SetEnvironmentVariable('S3_BUCKET', '",
+                {
+                  "Ref": "S3BucketName"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+
+                "$env:BUILD_NUMBER = [System.Environment]::GetEnvironmentVariable(\"BUILD_NUMBER\",\"Machine\") \n",
+                "$env:S3_BUCKET = [System.Environment]::GetEnvironmentVariable(\"S3_BUCKET\",\"Machine\") \n",
+
+                "Write-Host 'Generating Git RSA...' \n",
+                "$id_rsa = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('",
+                {
+                  "Ref": "GitPrivateKeyPart1"
+                },
+                {
+                  "Ref":"GitPrivateKeyPart2"
+                },
+                "')) \n",
+                "$key_value = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('",
+                {
+                  "Ref": "KeyValue"
+                },
+                "')) \n",
+                "$id_rsa_pub = '",
+                {
+                  "Ref": "GitPublicKey"
+                },
+                "' \n",
+                "$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False \n",
+                "[System.IO.File]::WriteAllLines( 'C:/Users/Administrator/.ssh/id_rsa', $id_rsa , $Utf8NoBomEncoding)\n",
+                "[System.IO.File]::WriteAllLines( 'C:/Users/Administrator/.ssh/id_rsa.pub', $id_rsa_pub , $Utf8NoBomEncoding)\n",
+                "[System.IO.File]::WriteAllLines( 'C:/Users/Administrator/guardian.txt', $key_value , $Utf8NoBomEncoding)\n",
+                "Write-Host 'Complete.' \n",
+
+                "Write-Host 'Start downloading the repo...'\n",
+                "cd C:\\Users\\Administrator \n",
+                "git clone git@github.com:mozilla-services/guardian-vpn-windows.git \n",
+                "cd guardian-vpn-windows \n",
+                "git fetch --force origin ",
+                {
+                  "Ref": "GitBranch"
+                },
+                "/head:remotes/origin/",
+                {
+                  "Ref": "GitBranch"
+                },"\n",
+                "git checkout ",
+                {
+                  "Ref": "GitBranch"
+                },"\n",
+                "Write-Host Downloaded!\n",              
+
+                "Write-Host 'Start Installing MSI' \n",
+                "cd C:\\Users\\Administrator \n",
+                "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force \n",
+                "Install-Module -Name AWS.Tools.S3,AWS.Tools.EC2 -Scope AllUsers -Force \n",
+                "Read-S3Object -BucketName $env:S3_BUCKET -Key msi/$env:BUILD_NUMBER/FirefoxPrivateNetworkVPN.msi -File FirefoxPrivateNetworkVPN.msi \n",
+                "Start-Process msiexec.exe -Wait -ArgumentList '/I FirefoxPrivateNetworkVPN.msi /quiet' -Verb RunAs \n",  
+                "Write-Host 'Complete.' \n",           
+
+                "Write-Host 'Build Smoke Test App' \n",
+                "cd C:\\Users\\Administrator\\guardian-vpn-windows\\test\\smoke\\FirefoxPrivateVPNUITest \n",
+                "C:\\nuget.exe restore -SolutionDirectory ./ \n",
+                "& 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\MSBuild\\Current\\Bin\\amd64\\MSBuild.exe' /t:Rebuild /p:Configuration=Release \n",
+                "Write-Host 'Finish building the app' \n",
+                
+                "Write-Host 'Install WinAppDriver' \n",
+                "reg add \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\AppModelUnlock\" /t REG_DWORD /f /v \"AllowDevelopmentWithoutDevLicense\" /d \"1\" \n",
+                "Invoke-WebRequest -Uri https://github.com/microsoft/WinAppDriver/releases/download/v1.2-RC/WindowsApplicationDriver.msi -OutFile WindowsApplicationDriver.msi \n",
+                "Start-Process msiexec.exe -Wait -ArgumentList '/I WindowsApplicationDriver.msi /quiet' \n",
+                "Write-Host 'Complete' \n",
+
+                "$RegPath = \"HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\" \n",
+                "$InstanceId = Get-EC2InstanceMetadata -Category InstanceId \n",
+                "$env:DEFAULT_PASSWORD = Get-EC2PasswordData -InstanceId $InstanceId -PemFile C:/Users/Administrator/guardian.txt \n",
+                "Set-ItemProperty $RegPath \"AutoAdminLogon\" -Value \"1\" -type String \n",
+                "Set-ItemProperty $RegPath \"DefaultUsername\" -Value \"administrator\" -type String \n",
+                "Set-ItemProperty $RegPath \"DefaultPassword\" -Value \"$env:DEFAULT_PASSWORD\" -type String \n",
+                "Write-Host \"Restarting Computer.\" -force -ForegroundColor Yellow \n",
+                "Restart-Computer -Force \n",
+                "</powershell>"
+              ]
+            ]
+          }
+        }
+      }
+    },
+    "ReadWriteS3BucketsInstanceProfile" : {
+      "Type" : "AWS::IAM::InstanceProfile",
+      "Properties" : {
+        "Path" : "/",
+        "Roles" : [
+          {
+            "Ref" : "ReadWriteS3BucketsRole"
+          }
+        ]
+      }
+    },
+    "ReadWriteS3BucketsPolicy" : {
+      "Type" : "AWS::IAM::Policy",
+      "Properties" : {
+        "PolicyName" : "ReadWriteS3BucketsPolicy",
+        "PolicyDocument" : {
+          "Statement" : [
+            {
+              "Effect" : "Allow",
+              "Action" : [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+              ],
+              "Resource" :{
+                "Fn::Join": [
+                  "", [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "S3BucketName"
+                    },
+                    "/*"
+                  ]
+                ]
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ec2:GetPasswordData"
+              ],
+              "Resource": "*"
+            }
+          ]
+        },
+        "Roles" : [
+          {
+            "Ref" : "ReadWriteS3BucketsRole"
+          }
+        ]
+      }
+    },
+    "ReadWriteS3BucketsRole" : {
+      "Type" : "AWS::IAM::Role",
+      "Properties" : {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement" : [
+            {
+              "Effect" : "Allow",
+              "Principal" : {
+                "Service" : ["ec2.amazonaws.com"]
+              },
+              "Action" : [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path" : "/"
+      }
+    },
+    "InstanceSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+        "GroupDescription" : "Enable RDP via port 3389",
+        "SecurityGroupIngress" : [ {
+          "IpProtocol" : "tcp",
+          "FromPort" : "3389",
+          "ToPort" : "3389",
+          "CidrIp" : { "Ref" : "IPLocation"}
+        } ]
+      }
+    }
+  },
+
+  "Outputs" : {
+    "InstanceId" : {
+      "Description" : "InstanceId of the newly created EC2 instance",
+      "Value" : { "Ref" : "EC2Instance" }
+    },
+    "AZ" : {
+      "Description" : "Availability Zone of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "AvailabilityZone" ] }
+    },
+    "PublicDNS" : {
+      "Description" : "Public DNSName of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicDnsName" ] }
+    },
+    "PublicIP" : {
+      "Description" : "Public IP address of the newly created EC2 instance",
+      "Value" : { "Fn::GetAtt" : [ "EC2Instance", "PublicIp" ] }
+    }
+  }
+}

--- a/test/smoke/aws/terminate_ec2.ps1
+++ b/test/smoke/aws/terminate_ec2.ps1
@@ -1,0 +1,5 @@
+Set-DefaultAWSRegion -Region us-east-1
+# remove the stack
+Remove-CFNStack -StackName guardian-stack-$env:CIRCLE_BUILD_NUM
+# wait stack to delete completely
+Wait-CFNStack -StackName guardian-stack-$env:CIRCLE_BUILD_NUM -Status DELETE_COMPLETE


### PR DESCRIPTION
In order to do smoke test, we need to simulate the real production environment which is in Windows 10. However the CircleCI is current using Windows server 2019 for all windows job and Windows server 2019 only has IE 11 installed. IE 11 is not supported by FxA anymore and cannot show user login web page properly. This is why we start using VM to do smoke test.