### PR TITLE
ui/tunnel/service: Broker service refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
             netsh http add urlacl url=http://+:8000/ user=Everyone
             Get-Process FirefoxPrivateNetworkVPN -ErrorAction SilentlyContinue | Stop-Process -Force
             Start-Process -FilePath ".\ui\src\bin\x64\Debug_QA\FirefoxPrivateNetworkVPN.exe"
+            Start-Service -Name "FirefoxPrivateNetworkVPNBroker"
       - run: 
           name: Run Integration Tests
           command: |

--- a/installer/FirefoxPrivateNetworkVPN.wxs
+++ b/installer/FirefoxPrivateNetworkVPN.wxs
@@ -80,6 +80,19 @@
 				<File Source="../ui/bin/$(var.Platform)/Release/Resources/Graphics/icon_70x70.png" />
 				<File Source="../ui/bin/$(var.Platform)/Release/Resources/Graphics/icon_150x150.png" />
 
+				<!-- Broker Service -->
+				<ServiceInstall
+					Type="ownProcess"
+					Name="FirefoxPrivateNetworkVPNBroker"
+					DisplayName="Firefox Private Network VPN Broker"
+					Description="Provides connectivity between the Firefox Private Network VPN client and any applicable tunnel interfaces."
+					Start="auto"
+					Arguments="broker"
+					ErrorControl="normal"
+					Vital="yes" />
+				<ServiceControl Id="StartService" Start="install" Stop="both" Remove="both" Name="FirefoxPrivateNetworkVPNBroker" Wait="yes" />
+
+				<!-- Remove Tunnel Service, if running -->
 				<ServiceControl Id="FirefoxPrivateNetworkVPNService" Remove="both" Name="WireGuardTunnel$FirefoxPrivateNetworkVPN" Stop="both" Wait="yes" />
 			</Component>
 		</ComponentGroup>

--- a/ui/src/App.xaml.cs
+++ b/ui/src/App.xaml.cs
@@ -14,7 +14,7 @@ namespace FirefoxPrivateNetwork
         private void Application_Exit(object sender, ExitEventArgs e)
         {
             // Ensure tunnel disconnect prior to exiting from the application.
-            Manager.Tunnel.Disconnect(false);
+            Manager.Tunnel.Disconnect();
 
             // Remove icon from the system tray.
             Manager.TrayIcon.Remove();

--- a/ui/src/Firefox Private Network.csproj
+++ b/ui/src/Firefox Private Network.csproj
@@ -383,6 +383,9 @@
     <Compile Include="WCF\VersionRequest.cs" />
     <Compile Include="Windows\WlanApi.cs" />
     <Compile Include="Windows\WlanApiStructures\WlanApiAdditionalStructures.cs" />
+    <Compile Include="WireGuard\BrokerService.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="WireGuard\WireGuardTunnelExitCodes.cs" />
     <Page Include="App.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/ui/src/Firefox Private Network.csproj.user
+++ b/ui/src/Firefox Private Network.csproj.user
@@ -9,5 +9,6 @@
     <ErrorReportUrlHistory />
     <FallbackCulture>en-US</FallbackCulture>
     <VerifyUploadedFiles>false</VerifyUploadedFiles>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
 </Project>

--- a/ui/src/FxA/Account.cs
+++ b/ui/src/FxA/Account.cs
@@ -110,7 +110,7 @@ namespace FirefoxPrivateNetwork.FxA
             try
             {
                 // Disconnect the VPN tunnel
-                Manager.Tunnel.Disconnect(false);
+                Manager.Tunnel.Disconnect();
 
                 // Remove the current account device
                 if (removeDevice)

--- a/ui/src/Manager.cs
+++ b/ui/src/Manager.cs
@@ -24,11 +24,6 @@ namespace FirefoxPrivateNetwork
         public static WireGuard.Tunnel Tunnel { get; set; }
 
         /// <summary>
-        /// Gets or sets the intermediary broker process.
-        /// </summary>
-        public static WireGuard.Broker Broker { get; set; }
-
-        /// <summary>
         /// Gets or sets the user's FxA account.
         /// </summary>
         public static FxA.Account Account { get; set; }
@@ -116,25 +111,13 @@ namespace FirefoxPrivateNetwork
         }
 
         /// <summary>
-        /// Initialize the Broker.
-        /// </summary>
-        public static void InitializeBroker()
-        {
-            if (Broker == null)
-            {
-                Broker = new WireGuard.Broker();
-            }
-        }
-
-        /// <summary>
         /// Initialize the Broker if not already initialized and then initialize the tunnel class.
         /// </summary>
         public static void InitializeTunnel()
         {
-            InitializeBroker();
             if (Tunnel == null)
             {
-                Tunnel = new WireGuard.Tunnel(Broker);
+                Tunnel = new WireGuard.Tunnel();
             }
         }
 

--- a/ui/src/ProductConstants.cs
+++ b/ui/src/ProductConstants.cs
@@ -38,6 +38,11 @@ namespace FirefoxPrivateNetwork
         public const string InternalAppName = "FirefoxPrivateNetworkVPN";
 
         /// <summary>
+        /// Name of the broker service.
+        /// </summary>
+        public const string BrokerServiceName = "FirefoxPrivateNetworkVPNBroker";
+
+        /// <summary>
         /// Tunnel service unique name. Must be prefixed with "WireGuard$".
         /// </summary>
         public const string TunnelServiceInternalName = "WireGuardTunnel$FirefoxPrivateNetworkVPN";

--- a/ui/src/UI/Resources/Localization/Translations/de.ftl
+++ b/ui/src/UI/Resources/Localization/Translations/de.ftl
@@ -214,6 +214,9 @@ toast-unable-to-connect = Verbindung kann nicht hergestellt werden.{" "}
 toast-try-again = Nochmal versuchen
 toast-feedback-submitted = Feedback abgeschickt!{" "}
 toast-feedback-undo = Rückgängig
+toast-service-communication-error = Unable to communicate with the {application-name} background service. Click to restart.
+toast-service-restart-error = We couldn't restart the background service. Please repair your installation of {application-name}.
+toast-service-restart-success = The {application-name} background service has been restored.
 
 ## ViewLog window
 viewlog-save-button = Speichern

--- a/ui/src/UI/Resources/Localization/Translations/en-us.ftl
+++ b/ui/src/UI/Resources/Localization/Translations/en-us.ftl
@@ -214,6 +214,9 @@ toast-unable-to-connect = Unable to connect.{" "}
 toast-try-again = Try again
 toast-feedback-submitted = Feedback submitted!{" "}
 toast-feedback-undo = Undo
+toast-service-communication-error = Unable to communicate with the {application-name} background service. Click to restart.
+toast-service-restart-error = We couldn't restart the background service. Please repair your installation of {application-name}.
+toast-service-restart-success = The {application-name} background service has been restored.
 
 ## ViewLog window
 viewlog-save-button = Save

--- a/ui/src/Update/Update.cs
+++ b/ui/src/Update/Update.cs
@@ -202,9 +202,6 @@ namespace FirefoxPrivateNetwork.Update
                         return UpdateResult.DisconnectTimeout;
                     }
 
-                    // Shut down broker before updating
-                    Manager.Broker.ShutDown();
-
                     ErrorHandling.ErrorHandler.WriteToLog("Running MSI update...", ErrorHandling.LogLevel.Info);
 
                     var msiUpdateLaunch = LaunchUpdatedApplication(fileName);

--- a/ui/src/Windows/Kernel32.cs
+++ b/ui/src/Windows/Kernel32.cs
@@ -8,23 +8,6 @@ using System.Runtime.InteropServices;
 namespace FirefoxPrivateNetwork.Windows
 {
     /// <summary>
-    /// Options for handle duplication.
-    /// </summary>
-    [Flags]
-    public enum DuplicateOptions : uint
-    {
-        /// <summary>
-        /// Closes the source handle. This occurs regardless of any error status returned.
-        /// </summary>
-        DUPLICATE_CLOSE_SOURCE = 0x00000001,
-
-        /// <summary>
-        /// Ignores the dwDesiredAccess parameter. The duplicate handle has the same access as the source handle.
-        /// </summary>
-        DUPLICATE_SAME_ACCESS = 0x00000002,
-    }
-
-    /// <summary>
     /// Moves an existing file or directory, including its children, with various move options.
     /// </summary>
     [Flags]
@@ -78,66 +61,6 @@ namespace FirefoxPrivateNetwork.Windows
     /// </summary>
     public class Kernel32
     {
-        /// <summary>
-        /// Duplicates an object handle.
-        /// </summary>
-        /// <param name="hSourceProcessHandle">A handle to the process with the handle to be duplicated.</param>
-        /// <param name="hSourceHandle">The handle to be duplicated.</param>
-        /// <param name="hTargetProcessHandle">A handle to the process that is to receive the duplicated handle.</param>
-        /// <param name="lpTargetHandle">A pointer to a variable that receives the duplicate handle.</param>
-        /// <param name="dwDesiredAccess">The access requested for the new handle.</param>
-        /// <param name="bInheritHandle">A variable that indicates whether the handle is inheritable.</param>
-        /// <param name="dwOptions">Optional duplication options.</param>
-        /// <returns>If the function succeeds, the return value is true.</returns>
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool DuplicateHandle(IntPtr hSourceProcessHandle, IntPtr hSourceHandle, IntPtr hTargetProcessHandle, out IntPtr lpTargetHandle, uint dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwOptions);
-
-        /// <summary>
-        /// Creates an anonymous pipe, and returns handles to the read and write ends of the pipe.
-        /// </summary>
-        /// <param name="hReadPipe">A pointer to a variable that receives the read handle for the pipe.</param>
-        /// <param name="hWritePipe">A pointer to a variable that receives the write handle for the pipe.</param>
-        /// <param name="lpPipeAttributes">A pointer to a SecurityAttributes structure that determines whether the returned handle can be inherited by child processes.</param>
-        /// <param name="nSize">The size of the buffer for the pipe, in bytes. If this parameter is zero, the system uses the default buffer size.</param>
-        /// <returns>If the function succeeds, the return value is true.</returns>
-        [DllImport("kernel32.dll")]
-        public static extern bool CreatePipe(out IntPtr hReadPipe, out IntPtr hWritePipe, SecurityAttributes lpPipeAttributes, uint nSize);
-
-        /// <summary>
-        /// Reads data from the specified file or input/output (I/O) device. Reads occur at the position specified by the file pointer if supported by the device.
-        /// </summary>
-        /// <param name="hFile">A handle to the device.</param>
-        /// <param name="lpBuffer">A pointer to the buffer that receives the data read from a file or device.</param>
-        /// <param name="nNumberOfBytesToRead">The maximum number of bytes to be read.</param>
-        /// <param name="lpNumberOfBytesRead">A pointer to the variable that receives the number of bytes read when using a synchronous hFile parameter.</param>
-        /// <param name="lpOverlapped">A pointer to an OVERLAPPED structure is required if the hFile parameter was opened with FILE_FLAG_OVERLAPPED, otherwise it can be NULL.</param>
-        /// <returns>If the function succeeds, the return value is true.</returns>
-        [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern bool ReadFile(IntPtr hFile, [Out] byte[] lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, IntPtr lpOverlapped);
-
-        /// <summary>
-        /// Writes data to the specified file or input/output (I/O) device.
-        /// </summary>
-        /// <param name="hFile">A handle to the file or I/O device.</param>
-        /// <param name="lpBuffer">A pointer to the buffer containing the data to be written to the file or device.</param>
-        /// <param name="nNumberOfBytesToWrite">The number of bytes to be written to the file or device.</param>
-        /// <param name="lpNumberOfBytesWritten">A pointer to the variable that receives the number of bytes written when using a synchronous hFile parameter.</param>
-        /// <param name="lpOverlapped">A pointer to an OVERLAPPED structure is required if the hFile parameter was opened with FILE_FLAG_OVERLAPPED, otherwise this parameter can be NULL.</param>
-        /// <returns>If the function succeeds, the return value is true.</returns>
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool WriteFile(IntPtr hFile, byte[] lpBuffer, uint nNumberOfBytesToWrite, out uint lpNumberOfBytesWritten, [In] IntPtr lpOverlapped);
-
-        /// <summary>
-        /// Closes an open object handle.
-        /// </summary>
-        /// <param name="hObject">A valid handle to an open object.</param>
-        /// <returns>If the function succeeds, the return value is true.</returns>
-        [DllImport("kernel32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool CloseHandle(IntPtr hObject);
-
         /// <summary>
         /// Sets the minimum and maximum working set sizes for the specified process.
         /// </summary>

--- a/ui/src/WireGuard/BrokerService.cs
+++ b/ui/src/WireGuard/BrokerService.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="BrokerService.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.ServiceProcess;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FirefoxPrivateNetwork.WireGuard
+{
+    /// <summary>
+    /// Broker service message handler with elevated privileges.
+    /// </summary>
+    public partial class BrokerService : ServiceBase
+    {
+        /// <summary>
+        /// Gets a cancellation token source for the broker process.
+        /// </summary>
+        public static CancellationTokenSource BrokerServiceTokenSource { get; private set; }
+
+        /// <inheritdoc/>
+        protected override void OnStart(string[] args)
+        {
+            // Initialize the broker service cancellation token
+            BrokerServiceTokenSource = new CancellationTokenSource();
+
+            // Start the initial broker child process
+            Broker.StartChildProcess();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnStop()
+        {
+            // Stop all spawned broker child processes
+            Broker.StopAllChildProcesses();
+        }
+    }
+}

--- a/ui/src/WireGuard/IPC/IPCCommand.cs
+++ b/ui/src/WireGuard/IPC/IPCCommand.cs
@@ -44,14 +44,14 @@ namespace FirefoxPrivateNetwork.WireGuard
         public const string IpcDetectCaptivePortalReply = "ipcdetectcaptiveportalreply=1";
 
         /// <summary>
-        /// Process ID reply command.
+        /// Request tunnel connection status.
         /// </summary>
-        public const string IpcPidReply = "ipcpid=1";
+        public const string IpcConnectionStatus = "ipcconnectionstatus=1";
 
         /// <summary>
-        /// Request a process ID.
+        /// Tunnel connection status reply.
         /// </summary>
-        public const string IpcRequestPid = "ipcpidrequest=1";
+        public const string IpcConnectionStatusReply = "ipcconnectionstatusreply=1";
 
         /// <summary>
         /// Unknown IPC command.


### PR DESCRIPTION
After some discussion, it has been decided to refactor our current methods for elevating processes.
Elevation will always be required, but prompting the user to do so every time is a nuisance. This PR addresses that by creating an always-on elevated service listening for requests and executes basic commands pertaining to bringing up/down the tunnel, as well as retrieving the latest tunnel connection info. This service is started after the MSI installation process completes.

We have not yet determined what will the permissions look like for interacting with this service, as multiple users on the same machine may have a need for controlling the tunnel. For the time being, it's a free for all. We will determine what's the best course of action before next release.