### PR TITLE
test: fix the bug on UI tests

### DIFF
--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/BrowserSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/BrowserSession.cs
@@ -5,8 +5,8 @@
 namespace FirefoxPrivateVPNUITest
 {
     using System;
+    using System.Threading;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
     using OpenQA.Selenium.Remote;
 
@@ -29,7 +29,6 @@ namespace FirefoxPrivateVPNUITest
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
                 appCapabilities.SetCapability("app", BrowserAppId);
                 this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
-                this.Session.Keyboard.SendKeys(Keys.Command + Keys.ArrowUp + Keys.Command);
                 Assert.IsNotNull(this.Session);
 
                 // Set implicit timeout to 1.5 seconds to make element search to retry every 500 ms for at most three times

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
@@ -5,6 +5,7 @@
 namespace FirefoxPrivateVPNUITest
 {
     using System;
+    using System.Threading;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using OpenQA.Selenium;
     using OpenQA.Selenium.Appium.Windows;
@@ -54,11 +55,13 @@ namespace FirefoxPrivateVPNUITest
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
                 appCapabilities.SetCapability("app", "Root");
                 var desktopSession = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
-                desktopSession.FindElementByName("Notification Chevron").Click();
+                var notification = desktopSession.FindElementByName("Notification Chevron");
+                notification.Click();
                 var clientTray = desktopSession.FindElementByName("Firefox Private Network VPN - Disconnected");
                 desktopSession.Mouse.ContextClick(clientTray.Coordinates);
                 var exitItem = desktopSession.FindElementByName("_Exit");
                 exitItem.Click();
+                notification.Click();
                 desktopSession.Quit();
                 this.Session = null;
             }

--- a/test/smoke/aws/template.json
+++ b/test/smoke/aws/template.json
@@ -180,6 +180,7 @@
                   "Ref": "StageUrl"
                 },
                 "\" \n",
+                "New-Item -ItemType directory -Path C:\\Users\\Administrator\\AppData\\Local\\Mozilla\\FirefoxPrivateNetworkVPN \n",
                 "New-Item -Path C:\\Users\\Administrator\\AppData\\Local\\Mozilla\\FirefoxPrivateNetworkVPN -Name \"settings.conf\" -Value $env:Settings \n",
                 "Write-Host 'Complete.' \n", 
 

--- a/test/smoke/aws/terminate_ec2.ps1
+++ b/test/smoke/aws/terminate_ec2.ps1
@@ -1,6 +1,6 @@
 Set-DefaultAWSRegion -Region us-east-1
 $stack = "guardian-stack-$env:CIRCLE_BUILD_NUM"
 # remove the stack
-Remove-CFNStack -StackName $stack
+Remove-CFNStack -StackName $stack -Force
 # wait stack to delete completely
 Wait-CFNStack -StackName $stack -Status DELETE_COMPLETE


### PR DESCRIPTION
There are a few bugs on UI tests. One of them is that the pipeline is not able to terminate the Cloudformation stack because Remove-CFNStack command needs user to confirm before terminating. The others are tests related such as maximized browser hide the UI of the vpn client and notification chevron is not auto closed on vm.