### PR TITLE
ui: Translation enabled within the tray icon context menu

### DIFF
--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
@@ -59,7 +59,7 @@ namespace FirefoxPrivateVPNUITest
                 notification.Click();
                 var clientTray = desktopSession.FindElementByName("Firefox Private Network VPN - Disconnected");
                 desktopSession.Mouse.ContextClick(clientTray.Coordinates);
-                var exitItem = desktopSession.FindElementByName("_Exit");
+                var exitItem = desktopSession.FindElementByName("E_xit");
                 exitItem.Click();
                 notification.Click();
                 desktopSession.Quit();

--- a/ui/src/Manager.cs
+++ b/ui/src/Manager.cs
@@ -99,12 +99,12 @@ namespace FirefoxPrivateNetwork
         public static void Initialize()
         {
             InitializeSettings();
+            InitializeTranslationService();
             InitializeTray();
             InitializeServerListCache();
             InitializeTunnel();
             InitializeAccount();
             InitializeViewModels();
-            InitializeTranslationService();
             InitializeWlanWatcher();
             InitializeCaptivePortalDetector();
             InitializeUIUpdaters();

--- a/ui/src/NotificationArea/Tray.cs
+++ b/ui/src/NotificationArea/Tray.cs
@@ -21,6 +21,9 @@ namespace FirefoxPrivateNetwork.NotificationArea
         private readonly MouseHookDelegate mouseHookDelegate;
         private ContextMenu contextMenu;
         private MenuItem menuConnectionStatus;
+        private MenuItem menuShow;
+        private MenuItem menuHide;
+        private MenuItem menuExit;
 
         private int outsideClickHook = 0;
         private string connectionStatusText;
@@ -153,7 +156,7 @@ namespace FirefoxPrivateNetwork.NotificationArea
         /// </summary>
         public void SetDisconnected()
         {
-            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", "Disconnected");
+            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", Manager.TranslationService.GetString("tray-disconnected"));
             SetContextMenuStatus(newText);
             notifyIcon.UpdateIcon(IconType.Disconnected, newText);
         }
@@ -163,27 +166,27 @@ namespace FirefoxPrivateNetwork.NotificationArea
         /// </summary>
         public void SetConnected()
         {
-            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", "Connected");
+            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", Manager.TranslationService.GetString("tray-connected"));
             SetContextMenuStatus(newText);
             notifyIcon.UpdateIcon(IconType.Connected, newText);
         }
 
         /// <summary>
-        /// Sets the TrayIcon to have an "idle" image as its icon.
+        /// Sets the TrayIcon to have an "unstable" image as its icon.
         /// </summary>
-        public void SetIdle()
+        public void SetUnstable()
         {
-            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", "Idle");
+            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", Manager.TranslationService.GetString("tray-unstable"));
             SetContextMenuStatus(newText);
             notifyIcon.UpdateIcon(IconType.Unstable, newText);
         }
 
         /// <summary>
-        /// Sets the TrayIcon to have an "error" image as its icon.
+        /// Sets the TrayIcon to have a "no signal" image as its icon.
         /// </summary>
-        public void SetUnstable()
+        public void SetNoSignal()
         {
-            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", "No Signal");
+            var newText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", Manager.TranslationService.GetString("tray-no-signal"));
             SetContextMenuStatus(newText);
             notifyIcon.UpdateIcon(IconType.NoSignal, newText);
         }
@@ -244,6 +247,61 @@ namespace FirefoxPrivateNetwork.NotificationArea
         }
 
         /// <summary>
+        /// Setup the right click menu for the Tray.
+        /// </summary>
+        /// <param name="connectionActive">If true, the menu label will indicate that we are connected.</param>
+        public void SetupMenu(bool connectionActive)
+        {
+            // "Exit" menu item
+            menuExit = new System.Windows.Controls.MenuItem
+            {
+                Header = Manager.TranslationService.GetString("tray-menu-exit"),
+            };
+            menuExit.Click += (sender, e) =>
+            {
+                HideMainWindow();
+                Application.Current.Shutdown();
+            };
+
+            // "Show" menu item
+            menuShow = new MenuItem
+            {
+                Header = Manager.TranslationService.GetString("tray-menu-show"),
+            };
+            menuShow.Click += (sender, e) =>
+            {
+                ShowMainWindow();
+            };
+
+            // "Hide" menu item
+            menuHide = new MenuItem
+            {
+                Header = Manager.TranslationService.GetString("tray-menu-hide"),
+            };
+            menuHide.Click += (sender, e) =>
+            {
+                HideMainWindow();
+            };
+
+            // App title and connection status
+            connectionStatusText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", connectionActive ? Manager.TranslationService.GetString("tray-connected") : Manager.TranslationService.GetString("tray-disconnected"));
+            menuConnectionStatus = new MenuItem()
+            {
+                Header = connectionStatusText,
+                IsEnabled = false,
+            };
+
+            contextMenu = new ContextMenu();
+
+            contextMenu.Items.Add(menuConnectionStatus);
+            contextMenu.Items.Add(new Separator());
+            contextMenu.Items.Add(menuShow);
+            contextMenu.Items.Add(menuHide);
+            contextMenu.Items.Add(new Separator());
+            contextMenu.Items.Add(menuExit);
+        }
+
+        /// <summary>
         /// Sets the context menu connection status text.
         /// </summary>
         /// <param name="text">Text to show as the connection status in the context menu.</param>
@@ -272,60 +330,6 @@ namespace FirefoxPrivateNetwork.NotificationArea
                 Windows.User32.UnhookWindowsHookEx(outsideClickHook);
                 outsideClickHook = 0;
             }
-        }
-
-        /// <summary>
-        /// Setup the right click menu for the Tray.
-        /// </summary>
-        private void SetupMenu(bool connectionActive)
-        {
-            // "Exit" menu item
-            var menuExit = new System.Windows.Controls.MenuItem
-            {
-                Header = "_Exit",
-            };
-            menuExit.Click += (sender, e) =>
-            {
-                HideMainWindow();
-                Application.Current.Shutdown();
-            };
-
-            // "Show" menu item
-            var menuShow = new MenuItem
-            {
-                Header = "_Show",
-            };
-            menuShow.Click += (sender, e) =>
-            {
-                ShowMainWindow();
-            };
-
-            // "Hide" menu item
-            var menuHide = new MenuItem
-            {
-                Header = "_Hide",
-            };
-            menuHide.Click += (sender, e) =>
-            {
-                HideMainWindow();
-            };
-
-            // App title and connection status
-            connectionStatusText = string.Concat(ProductConstants.DefaultSystemTrayTitle, " - ", connectionActive ? "Connected" : "Disconnected");
-            menuConnectionStatus = new MenuItem()
-            {
-                Header = connectionStatusText,
-                IsEnabled = false,
-            };
-
-            contextMenu = new ContextMenu();
-
-            contextMenu.Items.Add(menuConnectionStatus);
-            contextMenu.Items.Add(new Separator());
-            contextMenu.Items.Add(menuShow);
-            contextMenu.Items.Add(menuHide);
-            contextMenu.Items.Add(new Separator());
-            contextMenu.Items.Add(menuExit);
         }
     }
 }

--- a/ui/src/UI/Resources/Localization/TranslationService.cs
+++ b/ui/src/UI/Resources/Localization/TranslationService.cs
@@ -131,6 +131,12 @@ namespace FirefoxPrivateNetwork.UI.Resources.Localization
             };
 
             culture = new CultureInfo(cultureName);
+
+            // Refresh system tray, if available
+            if (Manager.TrayIcon != null)
+            {
+                Manager.TrayIcon.SetupMenu(true);
+            }
         }
 
         /// <summary>

--- a/ui/src/UI/Resources/Localization/Translations/de.ftl
+++ b/ui/src/UI/Resources/Localization/Translations/de.ftl
@@ -72,6 +72,11 @@ tray-disconnected = Getrennt
 tray-unstable = Instabil
 tray-no-signal = {hero-subtext-no-signal}
 
+## Tray menu
+tray-menu-exit = Be_enden
+tray-menu-show = _Anzeigen
+tray-menu-hide = A_usblenden
+
 ## Settings
 settings-auto-launch = VPN beim Hochfahren des Computers starten
 settings-unsecured-network-title = Alarm für unsichere Verbindungen

--- a/ui/src/UI/Resources/Localization/Translations/en-us.ftl
+++ b/ui/src/UI/Resources/Localization/Translations/en-us.ftl
@@ -72,6 +72,11 @@ tray-disconnected = Disconnected
 tray-unstable = Unstable
 tray-no-signal = {hero-subtext-no-signal}
 
+## Tray menu
+tray-menu-exit = E_xit
+tray-menu-show = _Show
+tray-menu-hide = _Hide
+
 ## Settings
 settings-auto-launch = Launch VPN app on computer startup
 settings-unsecured-network-title = Unsecured network alert

--- a/ui/src/UIUpdaters/ConnectionStatusUpdater.cs
+++ b/ui/src/UIUpdaters/ConnectionStatusUpdater.cs
@@ -205,12 +205,12 @@ namespace FirefoxPrivateNetwork.UIUpdaters
 
             if (newStability == Models.ConnectionStability.NoSignal)
             {
-                Manager.TrayIcon.SetUnstable();
+                Manager.TrayIcon.SetNoSignal();
                 return;
             }
             else if (newStability == Models.ConnectionStability.Unstable)
             {
-                Manager.TrayIcon.SetIdle();
+                Manager.TrayIcon.SetUnstable();
                 return;
             }
 


### PR DESCRIPTION
The tray context menu was missing some localization functionality. Fixed.