### PR TITLE
ui: make container of item in languages list not focusable

### DIFF
--- a/ui/src/UI/Views/Settings/LanguageView.xaml
+++ b/ui/src/UI/Views/Settings/LanguageView.xaml
@@ -73,6 +73,7 @@
                                 <Setter Property="Margin" Value="0"/>
                                 <Setter Property="BorderThickness" Value="0"/>
                                 <Setter Property="Background" Value="Yellow" />
+                                <Setter Property="Focusable" Value="False" />
                                 <Setter Property="Template">
                                     <Setter.Value>
                                         <ControlTemplate TargetType="{x:Type ListViewItem}">


### PR DESCRIPTION
- Prevent tabbing to language container before language radio button