### PR TITLE
ui: Modify connection server list to have one option per city

### DIFF
--- a/test/integrations/integration_helper.go
+++ b/test/integrations/integration_helper.go
@@ -81,7 +81,7 @@ func SubscriptionCheck(t *testing.T) {
 }
 
 func ListServers(t *testing.T) {
-	command := BASEURL + "/ServerList"
+	command := BASEURL + "/ServerCityList"
 	res := getJson(command)
 	servers := res.MustArray()
 	assert.Equal(t, true, len(servers) >= 0)

--- a/ui/Guardian.Tests/FirefoxPrivateNetwork.Tests.csproj
+++ b/ui/Guardian.Tests/FirefoxPrivateNetwork.Tests.csproj
@@ -138,6 +138,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ServerList\ServerSelectionTest.cs" />
     <Compile Include="ServerList\SortingAndRetrievalTest.cs" />
     <Compile Include="ServerList\RandomPortSelectionTest.cs" />
     <Compile Include="Versioning\VersioningTest.cs" />

--- a/ui/Guardian.Tests/ServerList/ServerSelectionTest.cs
+++ b/ui/Guardian.Tests/ServerList/ServerSelectionTest.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FirefoxPrivateNetwork.Tests.ServerList
+{
+    [TestFixture]
+    class ServerSelectionTest
+    {
+        public FxA.ServerList servers;
+        private List<Models.CityServerListItem> serverCityList;
+
+        [SetUp]
+        public void SetupServerListTest()
+        {
+            servers = new FxA.ServerList();
+            servers.LoadServerDataFromFile(Path.Combine(TestContext.CurrentContext.WorkDirectory, "Fixtures", "servers.json"));
+            serverCityList = servers.GetServerCitiesList();
+        }
+
+        [Test]
+        public void TestSelectServerWhenOneServer()
+        {
+            var selectedServer = servers.SelectServer(serverCityList.FirstOrDefault(x => x.City == "Brno"));
+            Assert.That(selectedServer.Endpoint == "193.9.112.115");
+        }
+
+        [Test]
+        public void TestSelectServerWhenTwoServers()
+        {
+            var selectedServer = servers.SelectServer(serverCityList.FirstOrDefault(x => x.City == "Wien"));
+            Assert.That(selectedServer.Endpoint == "185.210.219.242" || selectedServer.Endpoint == "5.253.207.34");
+        }
+    }
+}

--- a/ui/Guardian.Tests/ServerList/SortingAndRetrievalTest.cs
+++ b/ui/Guardian.Tests/ServerList/SortingAndRetrievalTest.cs
@@ -9,14 +9,14 @@ namespace FirefoxPrivateNetwork.Tests.ServerList
     class SortingAndRetrievalTest
     {
         private FxA.ServerList servers;
-        private List<Models.ServerListItem> serverList;
+        private List<Models.CityServerListItem> serverCityList;
 
         [SetUp]
         public void SetupServerListTest()
         {
             servers = new FxA.ServerList();
             servers.LoadServerDataFromFile(Path.Combine(TestContext.CurrentContext.WorkDirectory, "Fixtures", "servers.json"));
-            serverList = servers.GetServerList();
+            serverCityList = servers.GetServerCitiesList();
         }
 
         [Test]
@@ -25,7 +25,7 @@ namespace FirefoxPrivateNetwork.Tests.ServerList
             // For test coverage purposes, we need to call this again
             servers.LoadServerDataFromFile(Path.Combine(TestContext.CurrentContext.WorkDirectory, "Fixtures", "servers.json"));
 
-            Assert.AreEqual(9, serverList.Count);
+            Assert.AreEqual(5, serverCityList.Count);
 
             var vpnServerItems = servers.GetServerItems();
             Assert.AreEqual(9, vpnServerItems.Count);
@@ -77,12 +77,22 @@ namespace FirefoxPrivateNetwork.Tests.ServerList
         }
 
         [Test]
-        public void TestGetServerList()
+        public void TestGetServerCityList()
         {
-            var testServers = servers.GetServerList();
-            Assert.AreEqual(9, testServers.Count);
+            var testServerCities = servers.GetServerCitiesList();
+            Assert.AreEqual(5, testServerCities.Count);
 
-            var testServer = testServers[0];
+            var testCity = testServerCities[0];
+            Assert.AreEqual("Wien", testCity.City);
+        }
+
+        [Test]
+        public void TestGetServerSelection()
+        {
+            var testServerCities = servers.GetServerCitiesList();
+            Assert.AreEqual(5, testServerCities.Count);
+
+            var testServer = testServerCities[0].Servers[0];
             Assert.AreEqual("Wien 1", testServer.Name);
         }
 

--- a/ui/src/Models/CountryServerListItem.cs
+++ b/ui/src/Models/CountryServerListItem.cs
@@ -24,7 +24,7 @@ namespace FirefoxPrivateNetwork.Models
         /// <summary>
         /// Gets or sets the list of servers available within this country.
         /// </summary>
-        public List<ServerListItem> Servers { get; set; }
+        public List<CityServerListItem> Servers { get; set; }
 
         /// <summary>
         /// Gets the name of the country.

--- a/ui/src/Network/Pinger.cs
+++ b/ui/src/Network/Pinger.cs
@@ -62,7 +62,7 @@ namespace FirefoxPrivateNetwork.Network
                 {
                     if (Manager.MainWindowViewModel.Status == Models.ConnectionState.Protected)
                     {
-                        var currentServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerListSelectedItem.Endpoint);
+                        var currentServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerSelected.Endpoint);
                         Ping(currentServer.DNSServerAddress);
                     }
 

--- a/ui/src/UI/Views/ConnectionView.xaml
+++ b/ui/src/UI/Views/ConnectionView.xaml
@@ -175,7 +175,7 @@
                                                 <DataTrigger.Binding>
                                                     <MultiBinding Converter="{StaticResource EqualityConverter}">
                                                         <Binding Path="Country" Mode="OneTime" />
-                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionView}}" Path="DataContext.ServerListSelectedItem.Country" UpdateSourceTrigger="PropertyChanged" Mode="OneTime" />
+                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionView}}" Path="DataContext.ServerCityListSelectedItem.Country" UpdateSourceTrigger="PropertyChanged" Mode="OneTime" />
                                                     </MultiBinding>
                                                 </DataTrigger.Binding>
                                                 <Setter Property="IsExpanded" Value="True" />
@@ -215,15 +215,15 @@
                                     <ListView.ItemTemplate>
                                         <DataTemplate>
                                             <!-- City server radio button -->
-                                            <RadioButton Tag="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}" Margin="50,13,0,13" GroupName="SelectedServer" Content="{Binding Name}" Click="RadioButton_Click">
+                                            <RadioButton Tag="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListViewItem}}}" Margin="50,13,0,13" GroupName="SelectedServer" Content="{Binding City}" Click="RadioButton_Click">
                                                 <RadioButton.Style>
                                                     <Style BasedOn="{StaticResource Radio}" TargetType="{x:Type RadioButton}">
                                                         <Style.Triggers>
                                                             <DataTrigger Value="True">
                                                                 <DataTrigger.Binding>
                                                                     <MultiBinding Converter="{StaticResource EqualityConverter}">
-                                                                        <Binding Path="Endpoint" Mode="OneWay" />
-                                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionView}}" Path="DataContext.ServerListSelectedItem.Endpoint" UpdateSourceTrigger="PropertyChanged" Mode="OneWay" />
+                                                                        <Binding Path="City" Mode="OneWay" />
+                                                                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type local:ConnectionView}}" Path="DataContext.ServerSelected.City" UpdateSourceTrigger="PropertyChanged" Mode="OneWay" />
                                                                     </MultiBinding>
                                                                 </DataTrigger.Binding>
                                                                 <Setter Property="IsChecked" Value="True" />

--- a/ui/src/UI/Views/ConnectionView.xaml.cs
+++ b/ui/src/UI/Views/ConnectionView.xaml.cs
@@ -3,11 +3,13 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using FirefoxPrivateNetwork.FxA;
 
 namespace FirefoxPrivateNetwork.UI
 {
@@ -24,7 +26,7 @@ namespace FirefoxPrivateNetwork.UI
             InitializeComponent();
             DataContext = Manager.MainWindowViewModel;
 
-            var selectedServerIndex = FxA.Cache.FxAServerList.GetServerIndexByCountry(Manager.MainWindowViewModel.CountryServerList, Manager.MainWindowViewModel.ServerListSelectedItem.Country);
+            var selectedServerIndex = FxA.Cache.FxAServerList.GetServerIndexByCountry(Manager.MainWindowViewModel.CountryServerList, Manager.MainWindowViewModel.ServerCityListSelectedItem.Country);
             CountryServerList.Loaded += (s, e) => CountryServerList.ScrollIntoView(Manager.MainWindowViewModel.CountryServerList[selectedServerIndex]);
         }
 
@@ -38,17 +40,18 @@ namespace FirefoxPrivateNetwork.UI
         {
             var selectedItem = ((sender as RadioButton)?.Tag as ListViewItem)?.DataContext;
 
-            if (selectedItem is Models.ServerListItem selectedServer)
+            if (selectedItem is Models.CityServerListItem selectedCity)
             {
-                var previousSelectedItem = Manager.MainWindowViewModel.ServerListSelectedItem;
+                var previousSelectedCity = Manager.MainWindowViewModel.ServerCityListSelectedItem;
 
-                // Set the selected server
-                Manager.MainWindowViewModel.ServerListSelectedItem = selectedServer;
+                // Set the selected server city and server
+                Manager.MainWindowViewModel.ServerCityListSelectedItem = selectedCity;
+                Manager.MainWindowViewModel.UpdateServerSelection();
 
                 // Switch servers if presently connected, do nothing otherwise
                 if (Manager.MainWindowViewModel.Status == Models.ConnectionState.Protected)
                 {
-                    WireGuard.Connector.Connect(switchServer: true, previousServerCity: previousSelectedItem.Name, switchServerCity: selectedServer.Name);
+                    WireGuard.Connector.Connect(switchServer: true, previousServerCity: previousSelectedCity.City, switchServerCity: selectedCity.City);
                 }
 
                 NavigateMain(sender, e);

--- a/ui/src/UI/Views/MainView.xaml.cs
+++ b/ui/src/UI/Views/MainView.xaml.cs
@@ -40,12 +40,12 @@ namespace FirefoxPrivateNetwork.UI
 
         private void InitializeConnectionNavButton()
         {
-            if (Manager.MainWindowViewModel.ServerListSelectedItem == null)
+            if (Manager.MainWindowViewModel.ServerCityListSelectedItem == null)
             {
                 return;
             }
 
-            var selectedServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerListSelectedItem.Endpoint);
+            var selectedServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerSelected.Endpoint);
 
             if (selectedServer != null)
             {

--- a/ui/src/WCF/IService.cs
+++ b/ui/src/WCF/IService.cs
@@ -88,7 +88,7 @@ namespace FirefoxPrivateNetwork.WCF
         /// <returns>List of server list items.</returns>
         [OperationContract]
         [WebInvoke(Method = "GET", ResponseFormat = WebMessageFormat.Json)]
-        List<ServerListItem> ServerList();
+        List<CityServerListItem> ServerCityList();
 
         /// <summary>
         /// Device list stub.

--- a/ui/src/WCF/Service.cs
+++ b/ui/src/WCF/Service.cs
@@ -152,9 +152,9 @@ namespace FirefoxPrivateNetwork.WCF
         /// Retrieve server list.
         /// </summary>
         /// <returns>List of ServerListItems.</returns>
-        public List<ServerListItem> ServerList()
+        public List<CityServerListItem> ServerCityList()
         {
-            return FxA.Cache.FxAServerList.GetServerList();
+            return FxA.Cache.FxAServerList.GetServerCitiesList();
         }
 
         /// <summary>

--- a/ui/src/WireGuard/Connector.cs
+++ b/ui/src/WireGuard/Connector.cs
@@ -23,8 +23,8 @@ namespace FirefoxPrivateNetwork.WireGuard
             ErrorHandling.DebugLogger.LogDebugMsg("Connect command initiated");
             var configuration = new WireGuard.Config(ProductConstants.FirefoxPrivateNetworkConfFile);
 
-            ErrorHandling.DebugLogger.LogDebugMsg("Setting endpoint to", Manager.MainWindowViewModel.ServerListSelectedItem.Endpoint);
-            var currentServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerListSelectedItem.Endpoint);
+            ErrorHandling.DebugLogger.LogDebugMsg("Setting endpoint to", Manager.MainWindowViewModel.ServerSelected.Endpoint);
+            var currentServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerSelected.Endpoint);
             configuration.SetEndpoint(currentServer.GetEndpointWithRandomPort(), currentServer.PublicKey, ProductConstants.AllowedIPs, currentServer.DNSServerAddress);
 
             if (switchServer && Manager.MainWindowViewModel.Status == Models.ConnectionState.Protected)


### PR DESCRIPTION
- Remove multiple servers per city from connection list
- Select a server from the list of servers associated with the selected city according to the weight of each
- Modify existing tests for server list sorting and retrieval
- Add unit tests for server selection