### PR TITLE
test: Add new user login UI test

### DIFF
--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/Constants.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/Constants.cs
@@ -65,9 +65,29 @@ Do you wish to proceed?";
         /// </summary>
         public static readonly string AmIMullvadConnectedAPI = "https://am.i.mullvad.net/connected";
 
-         /// <summary>
-        /// Am I mullvad city API.
+        /// <summary>
+        /// Rest mail API.
         /// </summary>
-        public static readonly string AmIMullvadCityAPI = "https://am.i.mullvad.net/city";
+        public static readonly string RestMailAPI = "https://restmail.net/mail";
+
+        /// <summary>
+        /// New user name.
+        /// </summary>
+        public static readonly string NewUserName = $"automation-{Environment.GetEnvironmentVariable("BUILD_NUMBER")}";
+
+        /// <summary>
+        /// New user email.
+        /// </summary>
+        public static readonly string NewUserEmail = $"{NewUserName}@restmail.net";
+
+        /// <summary>
+        /// Key word in Payment url.
+        /// </summary>
+        public static readonly string KeyWordInPaymentUrl = $"payments";
+
+        /// <summary>
+        /// The default session timeout in seconds.
+        /// </summary>
+        public static readonly int SessionTimeoutInSeconds = 5;
     }
 }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/UserCommonOperation.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Common/UserCommonOperation.cs
@@ -20,8 +20,7 @@ namespace FirefoxPrivateVPNUITest
         /// </summary>
         /// <param name="vpnClient">VPN session.</param>
         /// <param name="browser">Browser session.</param>
-        /// <param name="disposeBrowser">Whether to dispose the browser after login.</param>
-        public static void UserSignIn(FirefoxPrivateVPNSession vpnClient, BrowserSession browser, bool disposeBrowser = true)
+        public static void UserSignIn(FirefoxPrivateVPNSession vpnClient, BrowserSession browser)
         {
             // Verify Account Screen
             vpnClient.Session.SwitchTo();
@@ -41,10 +40,6 @@ namespace FirefoxPrivateVPNUITest
             PasswordInputPage passwordInputPage = new PasswordInputPage(browser.Session);
             passwordInputPage.InputPassword(Environment.GetEnvironmentVariable("EXISTED_USER_PASSWORD"));
             passwordInputPage.ClickSignInButton();
-            if (disposeBrowser)
-            {
-                browser.Dispose();
-            }
 
             // Quick Access Screen
             vpnClient.Session.SwitchTo();

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.csproj
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest.csproj
@@ -46,6 +46,7 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -91,6 +92,8 @@
     <Compile Include="Screens\LogWindow.cs" />
     <Compile Include="Screens\MainScreen.cs" />
     <Compile Include="Screens\LastOnboardingScreen.cs" />
+    <Compile Include="Screens\ManageAccountPage.cs" />
+    <Compile Include="Screens\NetworkSettingsScreen.cs" />
     <Compile Include="Screens\NotificationsScreen.cs" />
     <Compile Include="Screens\OnboardingScreen.cs" />
     <Compile Include="Screens\PasswordInputPage.cs" />
@@ -102,6 +105,9 @@
     <Compile Include="Screens\RemoveDevicePopup.cs" />
     <Compile Include="Screens\ServerListScreen.cs" />
     <Compile Include="Screens\SettingScreen.cs" />
+    <Compile Include="Screens\SubscriptionPage.cs" />
+    <Compile Include="Screens\SubscriptionSuccessPage.cs" />
+    <Compile Include="Screens\VerificationCodePage.cs" />
     <Compile Include="Screens\VerifyAccountScreen.cs" />
     <Compile Include="Screens\WindowsNotificationScreen.cs" />
     <Compile Include="Sessions\BrowserSession.cs" />

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/DeviceScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/DeviceScreen.cs
@@ -44,7 +44,7 @@ namespace FirefoxPrivateVPNUITest.Screens
             var currentDeviceTextBlocks = this.currentDevice.FindElementsByClassName("TextBlock");
             this.currentDeviceName = currentDeviceTextBlocks[0];
             this.currentDeviceStatus = currentDeviceTextBlocks[1];
-            this.currentDeviceRemoveDeviceButton = this.currentDevice.FindElementByAccessibilityId("DeleteButton");
+            this.currentDeviceRemoveDeviceButton = Utils.WaitUntilFindElement(this.currentDevice.FindElementByAccessibilityId, "DeleteButton");
         }
 
         /// <summary>

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/EmailInputPage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/EmailInputPage.cs
@@ -20,8 +20,8 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="browserSession">browser session.</param>
         public EmailInputPage(WindowsDriver<WindowsElement> browserSession)
         {
-            this.emailTextBox = browserSession.FindElementByName("Email");
-            this.continueButton = browserSession.FindElementByAccessibilityId("submit-btn");
+            this.emailTextBox = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Email");
+            this.continueButton = Utils.WaitUntilFindElement(browserSession.FindElementByAccessibilityId, "submit-btn");
         }
 
         /// <summary>

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/MainScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/MainScreen.cs
@@ -29,7 +29,7 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="vpnSession">VPN session.</param>
         public MainScreen(WindowsDriver<WindowsElement> vpnSession)
         {
-            this.titleElement = vpnSession.FindElementByClassName("HeroText");
+            this.titleElement = Utils.WaitUntilFindElement(vpnSession.FindElementByClassName, "HeroText");
             this.subtitleElement = vpnSession.FindElementByClassName("HeroSubText");
             var settingButtons = vpnSession.FindElementsByName("Settings");
             this.vpnOffSettingButton = settingButtons[0];

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/ManageAccountPage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/ManageAccountPage.cs
@@ -1,0 +1,54 @@
+﻿// <copyright file="ManageAccountPage.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest.Screens
+{
+    using System;
+    using OpenQA.Selenium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// This model is for account manament page.
+    /// </summary>
+    internal class ManageAccountPage
+    {
+        private WindowsDriver<WindowsElement> browserSession;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManageAccountPage"/> class.
+        /// </summary>
+        /// <param name="browserSession">browser session.</param>
+        public ManageAccountPage(WindowsDriver<WindowsElement> browserSession)
+        {
+            this.browserSession = browserSession;
+        }
+
+        /// <summary>
+        /// Click delete button.
+        /// </summary>
+        public void ClickDeleteButton()
+        {
+            this.browserSession.Keyboard.SendKeys(Keys.PageDown);
+            var deleteButton = Utils.WaitUntilFindElement(this.browserSession.FindElementByName, "Delete…");
+            deleteButton.Click();
+        }
+
+        /// <summary>
+        /// To confirm deleting the account.
+        /// </summary>
+        /// <param name="password">The new user password.</param>
+        public void ConfirmDeleteAccount(string password)
+        {
+            this.browserSession.Keyboard.SendKeys(Keys.PageDown);
+            this.browserSession.FindElementByAccessibilityId("delete-account-subscriptions").Click();
+            this.browserSession.FindElementByAccessibilityId("delete-account-saved-info").Click();
+            this.browserSession.FindElementByAccessibilityId("delete-account-reactivate").Click();
+
+            var passwordInput = this.browserSession.FindElementByName("Password");
+            passwordInput.SendKeys(password);
+
+            this.browserSession.FindElementByName("Delete account").Click();
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/NetworkSettingsScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/NetworkSettingsScreen.cs
@@ -1,0 +1,183 @@
+﻿// <copyright file="NetworkSettingsScreen.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest.Screens
+{
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// This model is for Notification screen.
+    /// </summary>
+    internal class NetworkSettingsScreen
+    {
+        private AppiumWebElement backButton;
+        private AppiumWebElement title;
+        private AppiumWebElement enableIPv6CheckBox;
+        private AppiumWebElement enableIPv6Description;
+        private AppiumWebElement enableIPv6DisabledMessage;
+        private AppiumWebElement allowAccessCheckbox;
+        private AppiumWebElement allowAccessDescription;
+        private AppiumWebElement allowAccessDisabledMessage;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NetworkSettingsScreen"/> class.
+        /// </summary>
+        /// <param name="vpnSession">VPN session.</param>
+        public NetworkSettingsScreen(WindowsDriver<WindowsElement> vpnSession)
+        {
+            var networkSettingsView = vpnSession.FindElementByClassName("NetworkSettingsView");
+            this.backButton = networkSettingsView.FindElementByName("Back");
+            this.title = networkSettingsView.FindElementByName("Network settings");
+            var networkSettingsPanel = networkSettingsView.FindElementByClassName("ScrollViewer");
+            this.allowAccessCheckbox = networkSettingsPanel.FindElementByAccessibilityId("AllowLocalDeviceAccessCheckBox");
+            this.allowAccessDescription = networkSettingsPanel.FindElementByName("Access printers, streaming sticks and all other devices on your local network");
+            this.allowAccessDisabledMessage = networkSettingsPanel.FindElementByAccessibilityId("AllowLocalDeviceAccessCheckBoxDisabledMessage");
+            this.enableIPv6CheckBox = networkSettingsPanel.FindElementByAccessibilityId("EnableIPv6CheckBox");
+            this.enableIPv6Description = networkSettingsPanel.FindElementByName("Push the internet forward with the latest version of the Internet Protocol");
+            this.enableIPv6DisabledMessage = networkSettingsPanel.FindElementByAccessibilityId("EnableIPv6CheckBoxDisabledMessage");
+        }
+
+        /// <summary>
+        /// Get title on Network settings screen.
+        /// </summary>
+        /// <returns>The title string.</returns>
+        public string GetTitle()
+        {
+            return this.title.Text;
+        }
+
+        /// <summary>
+        /// Get the text on enable IPv6 checkbox.
+        /// </summary>
+        /// <returns>The text on enable IPv6 checkbox.</returns>
+        public string GetEnableIPv6CheckBoxText()
+        {
+            return this.enableIPv6CheckBox.Text;
+        }
+
+        /// <summary>
+        /// Get the description of enable IPv6 checkbox.
+        /// </summary>
+        /// <returns>The description of enable IPv6 checkbox.</returns>
+        public string GetEnableIPv6Description()
+        {
+            return this.enableIPv6Description.Text;
+        }
+
+        /// <summary>
+        /// Click the enable IPv6 checkbox.
+        /// </summary>
+        public void ClickEnableIPv6CheckBox()
+        {
+            this.enableIPv6CheckBox.Click();
+        }
+
+        /// <summary>
+        /// Is Enable IPv6 disabled message displayed.
+        /// </summary>
+        /// <returns>Enable IPv6 disabled message displayed or not.</returns>
+        public bool IsEnableIPv6DisabledMessageDisplayed()
+        {
+            return this.enableIPv6DisabledMessage.Displayed;
+        }
+
+        /// <summary>
+        /// Is enable IPv6 checked.
+        /// </summary>
+        /// <returns>Enable IPv6 checked or not.</returns>
+        public bool IsEnableIPv6Checked()
+        {
+            return this.enableIPv6CheckBox.Selected;
+        }
+
+        /// <summary>
+        /// Is enable IPv6 enabled.
+        /// </summary>
+        /// <returns>Enable IPv6 enabled or not.</returns>
+        public bool IsEnableIPv6Enabled()
+        {
+            return this.enableIPv6CheckBox.Enabled;
+        }
+
+        /// <summary>
+        /// Get enable IPv6 disabled message.
+        /// </summary>
+        /// <returns>Enable IPv6 disabled message</returns>
+        public string GetEnableIPv6DisabledMessage()
+        {
+            return this.enableIPv6DisabledMessage.Text;
+        }
+
+        /// <summary>
+        /// Get the text on Allow access checkbox.
+        /// </summary>
+        /// <returns>The text on allow access checkbox.</returns>
+        public string GetAllowAccessText()
+        {
+            return this.allowAccessCheckbox.Text;
+        }
+
+        /// <summary>
+        /// Get the description of the allow access checkbox.
+        /// </summary>
+        /// <returns>The description of the allow access checkbox.</returns>
+        public string GetAllowAccessDescription()
+        {
+            return this.allowAccessDescription.Text;
+        }
+
+        /// <summary>
+        /// Click the Allow Access check box.
+        /// </summary>
+        public void ClickAllowAccessCheckBox()
+        {
+            this.allowAccessCheckbox.Click();
+        }
+
+        /// <summary>
+        /// Is Allow access disabled message displayed.
+        /// </summary>
+        /// <returns>Allow access disabled message displayed or not.</returns>
+        public bool IsAllowAccessDisabledMessageDisplayed()
+        {
+            return this.allowAccessDisabledMessage.Displayed;
+        }
+
+        /// <summary>
+        /// Is Allow access checked.
+        /// </summary>
+        /// <returns>Allow access checked or not.</returns>
+        public bool IsAllowAccessChecked()
+        {
+            return this.allowAccessCheckbox.Selected;
+        }
+
+        /// <summary>
+        /// Is allow access enabled.
+        /// </summary>
+        /// <returns>Allow access enabled or not.</returns>
+        public bool IsAllowAccessEnabled()
+        {
+            return this.allowAccessCheckbox.Enabled;
+        }
+
+        /// <summary>
+        /// Get allow access disabled message.
+        /// </summary>
+        /// <returns>Allow access disabled message</returns>
+        public string GetAllowAccessDisabledMessage()
+        {
+            return this.allowAccessDisabledMessage.Text;
+        }
+
+        /// <summary>
+        /// Click the Back button.
+        /// </summary>
+        public void ClickBackButton()
+        {
+            this.backButton.Click();
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/RegisterPage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/RegisterPage.cs
@@ -4,6 +4,7 @@
 
 namespace FirefoxPrivateVPNUITest.Screens
 {
+    using System;
     using OpenQA.Selenium.Appium.Windows;
 
     /// <summary>
@@ -15,6 +16,7 @@ namespace FirefoxPrivateVPNUITest.Screens
         private WindowsElement repeatPasswordTextBox;
         private WindowsElement createAccountButton;
         private WindowsElement ageTextBox;
+        private WindowsDriver<WindowsElement> browserSession;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegisterPage"/> class.
@@ -22,10 +24,11 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="browserSession">browser session.</param>
         public RegisterPage(WindowsDriver<WindowsElement> browserSession)
         {
-            this.passwordTextBox = browserSession.FindElementByName("Password");
-            this.repeatPasswordTextBox = browserSession.FindElementByName("Repeat password");
-            this.createAccountButton = browserSession.FindElementByName("Create account");
-            this.ageTextBox = browserSession.FindElementByName("How old are you?");
+            this.browserSession = browserSession;
+            this.passwordTextBox = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Password");
+            this.repeatPasswordTextBox = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Repeat password");
+            this.createAccountButton = Utils.WaitUntilFindElement(browserSession.FindElementByAccessibilityId, "submit-btn");
+            this.ageTextBox = Utils.WaitUntilFindElement(browserSession.FindElementByName, "How old are you?");
         }
 
         /// <summary>
@@ -34,6 +37,7 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="password">user password.</param>
         public void InputPassword(string password)
         {
+            this.passwordTextBox.Click();
             this.passwordTextBox.Clear();
             this.passwordTextBox.SendKeys(password);
         }
@@ -44,6 +48,7 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="repeatPassword">user password.</param>
         public void InputRepeatPassword(string repeatPassword)
         {
+            this.repeatPasswordTextBox.Click();
             this.repeatPasswordTextBox.Clear();
             this.repeatPasswordTextBox.SendKeys(repeatPassword);
         }
@@ -53,7 +58,17 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// </summary>
         public void ClickCreateAccountButton()
         {
-            this.createAccountButton.Click();
+            try
+            {
+                this.createAccountButton.Click();
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message == "An element command could not be completed because the element is not pointer- or keyboard interactable.")
+                {
+                    this.browserSession.FindElementByName("Create account").Click();
+                }
+            }
         }
 
         /// <summary>
@@ -62,6 +77,7 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="age">user age.</param>
         public void InputAge(string age)
         {
+            this.ageTextBox.Click();
             this.ageTextBox.Clear();
             this.ageTextBox.SendKeys(age);
         }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/ServerListScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/ServerListScreen.cs
@@ -5,6 +5,7 @@
 namespace FirefoxPrivateVPNUITest.Screens
 {
     using System;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Threading;
     using OpenQA.Selenium.Appium;
@@ -109,7 +110,8 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="city">The city we want to select.</param>
         public void RandomSelectDifferentCityServer(string city = null)
         {
-            var cityList = this.selectedServerCountryCityList.FindElementsByClassName("RadioButton");
+            ReadOnlyCollection<AppiumWebElement> cityList = null;
+            Utils.WaitUntil(ref cityList, this.selectedServerCountryCityList.FindElementsByClassName, "RadioButton", (elements) => elements.Count > 0);
             Func<int, bool> randomPickCondition = (i) =>
             {
                 string currentCityName = cityList[i].GetAttribute("Name");

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/SettingScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/SettingScreen.cs
@@ -21,10 +21,8 @@ namespace FirefoxPrivateVPNUITest.Screens
         private AppiumWebElement profileImage;
         private AppiumWebElement userName;
         private AppiumWebElement manageAccountButton;
-        private AppiumWebElement allowAccessCheckbox;
-        private AppiumWebElement allowAccessDescription;
-        private AppiumWebElement allowAccessDisabledMessage;
         private AppiumWebElement launchVPNStartupCheckbox;
+        private AppiumWebElement networkSettingButton;
         private AppiumWebElement notificationButton;
         private AppiumWebElement languageButton;
         private AppiumWebElement aboutButton;
@@ -39,28 +37,23 @@ namespace FirefoxPrivateVPNUITest.Screens
         /// <param name="vpnSession">VPN session.</param>
         public SettingScreen(WindowsDriver<WindowsElement> vpnSession)
         {
-            if (this.vpnSession == null)
-            {
-                this.vpnSession = vpnSession;
-            }
-
-            this.backButton = vpnSession.FindElementByName("Back");
-            this.titleText = vpnSession.FindElementByName("Settings");
-            this.signOutButton = vpnSession.FindElementByName("Sign out");
-            this.scrollDownButton = vpnSession.FindElementByAccessibilityId("PART_LineDownButton");
-            this.profileImage = vpnSession.FindElementByAccessibilityId("ProfileImageButton");
-            this.userName = vpnSession.FindElementByName(Environment.GetEnvironmentVariable("EXISTED_USER_NAME"));
-            this.manageAccountButton = vpnSession.FindElementByName("Manage account");
-            this.allowAccessCheckbox = vpnSession.FindElementByAccessibilityId("AllowLocalDeviceAccessCheckBox");
-            this.allowAccessDescription = vpnSession.FindElementByName("Access printers, streaming sticks and all other devices on your local network");
-            this.allowAccessDisabledMessage = vpnSession.FindElementByAccessibilityId("AllowLocalDeviceAccessCheckBoxDisabledMessage");
-            this.launchVPNStartupCheckbox = vpnSession.FindElementByName("Launch VPN app on computer startup");
-            this.notificationButton = vpnSession.FindElementByAccessibilityId("NotificationsNavButton");
-            this.languageButton = vpnSession.FindElementByAccessibilityId("LanguageNavButton");
-            this.aboutButton = vpnSession.FindElementByAccessibilityId("AboutNavButton");
-            this.helpButton = vpnSession.FindElementByAccessibilityId("GetHelpNavButton");
-            this.giveFeedbackText = vpnSession.FindElementByName("Give feedback");
-            this.giveFeedbackLinkButton = vpnSession.FindElementByName("Open link");
+            this.vpnSession = vpnSession;
+            var settingView = vpnSession.FindElementByClassName("SettingsView");
+            this.backButton = settingView.FindElementByName("Back");
+            this.titleText = settingView.FindElementByName("Settings");
+            this.signOutButton = settingView.FindElementByName("Sign out");
+            this.scrollDownButton = settingView.FindElementByAccessibilityId("PART_LineDownButton");
+            this.profileImage = settingView.FindElementByAccessibilityId("ProfileImageButton");
+            this.userName = settingView.FindElementByClassName("ScrollViewer").FindElementsByClassName("TextBlock")[1];
+            this.manageAccountButton = settingView.FindElementByName("Manage account");
+            this.launchVPNStartupCheckbox = settingView.FindElementByName("Launch VPN app on computer startup");
+            this.notificationButton = settingView.FindElementByAccessibilityId("NotificationsNavButton");
+            this.networkSettingButton = settingView.FindElementByAccessibilityId("NetworkSettingsNavButton");
+            this.languageButton = settingView.FindElementByAccessibilityId("LanguageNavButton");
+            this.aboutButton = settingView.FindElementByAccessibilityId("AboutNavButton");
+            this.helpButton = settingView.FindElementByAccessibilityId("GetHelpNavButton");
+            this.giveFeedbackText = settingView.FindElementByName("Give feedback");
+            this.giveFeedbackLinkButton = settingView.FindElementByName("Open link");
         }
 
         /// <summary>
@@ -128,41 +121,6 @@ namespace FirefoxPrivateVPNUITest.Screens
         }
 
         /// <summary>
-        /// Get the text on Allow access checkbox.
-        /// </summary>
-        /// <returns>The text on allow access checkbox.</returns>
-        public string GetAllowAccessText()
-        {
-            return this.allowAccessCheckbox.Text;
-        }
-
-        /// <summary>
-        /// Get the description of the allow access checkbox.
-        /// </summary>
-        /// <returns>The description of the allow access checkbox.</returns>
-        public string GetAllowAccessDescription()
-        {
-            return this.allowAccessDescription.Text;
-        }
-
-        /// <summary>
-        /// Click the Allow Access check box.
-        /// </summary>
-        public void ClickAllowAccessCheckBox()
-        {
-            this.allowAccessCheckbox.Click();
-        }
-
-        /// <summary>
-        /// Get the Allow access disabled message element.
-        /// </summary>
-        /// <returns>The Allow access disabled message element.</returns>
-        public AppiumWebElement GetAllowAccessDisabledMessage()
-        {
-            return this.allowAccessDisabledMessage;
-        }
-
-        /// <summary>
         /// Get the text on Launch VPN on computer startup.
         /// </summary>
         /// <returns>The text on Launch VPN on computer startup.</returns>
@@ -185,6 +143,14 @@ namespace FirefoxPrivateVPNUITest.Screens
         public void ClickNotificationButton()
         {
             this.notificationButton.Click();
+        }
+
+        /// <summary>
+        /// Click the network setting button.
+        /// </summary>
+        public void ClickNetworkSettingButton()
+        {
+            this.networkSettingButton.Click();
         }
 
         /// <summary>
@@ -226,6 +192,15 @@ namespace FirefoxPrivateVPNUITest.Screens
         public string GetNotificationButtonText()
         {
             return this.notificationButton.Text;
+        }
+
+        /// <summary>
+        /// Get the text on network setting button.
+        /// </summary>
+        /// <returns>The text on network setting button.</returns>
+        public string GetNetworkSettingButtonText()
+        {
+            return this.networkSettingButton.Text;
         }
 
         /// <summary>
@@ -271,15 +246,6 @@ namespace FirefoxPrivateVPNUITest.Screens
         public string GetManageAccountButtonText()
         {
             return this.manageAccountButton.Text;
-        }
-
-        /// <summary>
-        /// Get Allow access checkbox.
-        /// </summary>
-        /// <returns>The allow access checkbox.</returns>
-        public AppiumWebElement GetAllowAccessCheckBox()
-        {
-            return this.allowAccessCheckbox;
         }
 
         /// <summary>

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/SubscriptionPage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/SubscriptionPage.cs
@@ -1,0 +1,109 @@
+﻿// <copyright file="SubscriptionPage.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest.Screens
+{
+    using OpenQA.Selenium.Appium;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// This model is for verification code page.
+    /// </summary>
+    internal class SubscriptionPage
+    {
+        private AppiumWebElement fullNameInput;
+        private AppiumWebElement cardNumberInput;
+        private AppiumWebElement expDateInput;
+        private AppiumWebElement cvcInput;
+        private AppiumWebElement zipCodeInput;
+        private AppiumWebElement authorizeCheckbox;
+        private AppiumWebElement submit;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubscriptionPage"/> class.
+        /// </summary>
+        /// <param name="browserSession">browser session.</param>
+        public SubscriptionPage(WindowsDriver<WindowsElement> browserSession)
+        {
+            this.fullNameInput = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Name as it appears on your card Full Name");
+            this.cardNumberInput = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Credit or debit card number");
+            this.expDateInput = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Credit or debit card expiration date");
+            this.cvcInput = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Credit or debit card CVC/CVV");
+            this.zipCodeInput = Utils.WaitUntilFindElement(browserSession.FindElementByName, "ZIP code 12345");
+            this.authorizeCheckbox = Utils.WaitUntilFindElement(browserSession.FindElementByName, "I authorize Mozilla, maker of Firefox products, to charge my payment method $9.99 per month , according to payment terms, until I cancel my subscription.");
+            this.submit = Utils.WaitUntilFindElement(browserSession.FindElementByName, "Submit");
+        }
+
+        /// <summary>
+        /// Input full name.
+        /// </summary>
+        /// <param name="fullName">Full name.</param>
+        public void InputFullName(string fullName)
+        {
+            this.fullNameInput.Click();
+            this.fullNameInput.Clear();
+            this.fullNameInput.SendKeys(fullName);
+        }
+
+        /// <summary>
+        /// Input card number.
+        /// </summary>
+        /// <param name="cardNumber">Card number.</param>
+        public void InputCardNumber(string cardNumber)
+        {
+            this.cardNumberInput.Click();
+            this.cardNumberInput.Clear();
+            this.cardNumberInput.SendKeys(cardNumber);
+        }
+
+        /// <summary>
+        /// Input exp date.
+        /// </summary>
+        /// <param name="expDate">Exp. date.</param>
+        public void InputExpDate(string expDate)
+        {
+            this.expDateInput.Click();
+            this.expDateInput.Clear();
+            this.expDateInput.SendKeys(expDate);
+        }
+
+        /// <summary>
+        /// Input cvc.
+        /// </summary>
+        /// <param name="cvc">CVC.</param>
+        public void InputCVC(string cvc)
+        {
+            this.cvcInput.Click();
+            this.cvcInput.Clear();
+            this.cvcInput.SendKeys(cvc);
+        }
+
+        /// <summary>
+        /// Input zip code.
+        /// </summary>
+        /// <param name="zipCode">Zip code.</param>
+        public void InputZipCode(string zipCode)
+        {
+            this.zipCodeInput.Click();
+            this.zipCodeInput.Clear();
+            this.zipCodeInput.SendKeys(zipCode);
+        }
+
+        /// <summary>
+        /// Check the authorize checkbox.
+        /// </summary>
+        public void ClickAuthorizeCheckBox()
+        {
+            this.authorizeCheckbox.Click();
+        }
+
+        /// <summary>
+        /// Click submit button.
+        /// </summary>
+        public void ClickSubmitButton()
+        {
+            this.submit.Click();
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/SubscriptionSuccessPage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/SubscriptionSuccessPage.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="SubscriptionSuccessPage.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest.Screens
+{
+    using System;
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// This model is for verification code page.
+    /// </summary>
+    internal class SubscriptionSuccessPage
+    {
+        private WindowsElement takeMeToProductLink;
+        private WindowsDriver<WindowsElement> browserSession;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubscriptionSuccessPage"/> class.
+        /// </summary>
+        /// <param name="browserSession">browser session.</param>
+        public SubscriptionSuccessPage(WindowsDriver<WindowsElement> browserSession)
+        {
+            this.browserSession = browserSession;
+            this.takeMeToProductLink = Utils.WaitUntilFindElement(browserSession.FindElementByName, "No thanks, just take me to my product.");
+        }
+
+        /// <summary>
+        /// Click verify button.
+        /// </summary>
+        public void ClickTakeMeToProductLink()
+        {
+            try
+            {
+                this.takeMeToProductLink.Click();
+            }
+            catch (Exception)
+            {
+                this.browserSession.FindElementByName("No thanks, just take me to my product.").Click();
+            }
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/VerificationCodePage.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/VerificationCodePage.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="VerificationCodePage.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+namespace FirefoxPrivateVPNUITest.Screens
+{
+    using OpenQA.Selenium.Appium.Windows;
+
+    /// <summary>
+    /// This model is for verification code page.
+    /// </summary>
+    internal class VerificationCodePage
+    {
+        private WindowsElement verificationCodeInput;
+        private WindowsElement verifyButton;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VerificationCodePage"/> class.
+        /// </summary>
+        /// <param name="browserSession">browser session.</param>
+        public VerificationCodePage(WindowsDriver<WindowsElement> browserSession)
+        {
+            this.verificationCodeInput = browserSession.FindElementByName("Enter 6-digit code");
+            this.verifyButton = browserSession.FindElementByName("Verify");
+        }
+
+        /// <summary>
+        /// Input the verification code.
+        /// </summary>
+        /// <param name="verificationCode">Verification code.</param>
+        public void InputVerificationCode(string verificationCode)
+        {
+            this.verificationCodeInput.Click();
+            this.verificationCodeInput.Clear();
+            this.verificationCodeInput.SendKeys(verificationCode);
+        }
+
+        /// <summary>
+        /// Click verify button.
+        /// </summary>
+        public void ClickVerifyButton()
+        {
+            this.verifyButton.Click();
+        }
+    }
+}

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/WindowsNotificationScreen.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Screens/WindowsNotificationScreen.cs
@@ -32,9 +32,8 @@ namespace FirefoxPrivateVPNUITest.Screens
             }
             catch (Exception)
             {
-                desktopSession.FindElementByName("Action Center").Click();
-                var actionCenterWindow = Utils.WaitUntilFindElement(desktopSession.FindElementByName, "Action center");
-                var notification = actionCenterWindow.FindElementByName("Notifications from Firefox Private Network VPN");
+                Utils.WaitUntilFindElement(desktopSession.FindElementByName, "Action Center").Click();
+                var notification = Utils.WaitUntilFindElement(desktopSession.FindElementByName, "Notifications from Firefox Private Network VPN");
                 var latestNotification = notification.FindElementByClassName("ListViewItem");
                 this.titleText = latestNotification.FindElementByAccessibilityId("Title");
                 this.messageText = latestNotification.FindElementByAccessibilityId("Content");

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/BrowserSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/BrowserSession.cs
@@ -34,7 +34,7 @@ namespace FirefoxPrivateVPNUITest
                 capabilities.SetCapability("app", BrowserAppId);
                 try
                 {
-                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), capabilities);
+                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), capabilities, TimeSpan.FromSeconds(Constants.SessionTimeoutInSeconds));
                     Assert.IsNotNull(this.Session);
                 }
                 catch (Exception)
@@ -69,7 +69,7 @@ namespace FirefoxPrivateVPNUITest
                     DesiredCapabilities appCapabilities = new DesiredCapabilities();
                     appCapabilities.SetCapability("deviceName", "WindowsPC");
                     appCapabilities.SetCapability("appTopLevelWindow", applicationSessionHandle);
-                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities, TimeSpan.FromSeconds(Constants.SessionTimeoutInSeconds));
                 }
 
                 // Set implicit timeout to 1.5 seconds to make element search to retry every 500 ms for at most three times
@@ -112,7 +112,9 @@ namespace FirefoxPrivateVPNUITest
         public string GetCurrentUrl()
         {
             Utils.WaitUntilFindElement(this.Session.FindElementByAccessibilityId, "reload-button");
-            var urlInput = this.Session.FindElementByAccessibilityId("urlbar-input");
+
+            // The browser will redirect url and we need more time to wait
+            var urlInput = Utils.WaitUntilFindElement(this.Session.FindElementByAccessibilityId, "urlbar-input", 15000);
             return urlInput.Text;
         }
 

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/DesktopSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/DesktopSession.cs
@@ -24,7 +24,7 @@ namespace FirefoxPrivateVPNUITest
             {
                 DesiredCapabilities appCapabilities = new DesiredCapabilities();
                 appCapabilities.SetCapability("app", "Root");
-                this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities, TimeSpan.FromSeconds(10));
+                this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities, TimeSpan.FromSeconds(Constants.SessionTimeoutInSeconds));
                 this.Session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1.5);
             }
         }
@@ -57,7 +57,8 @@ namespace FirefoxPrivateVPNUITest
             notification.Click();
             var clientTray = this.Session.FindElementByName("Firefox Private Network VPN - Disconnected");
             this.Session.Mouse.ContextClick(clientTray.Coordinates);
-            var exitItem = this.Session.FindElementByName("E_xit");
+            WindowsElement menu = Utils.WaitUntilFindElement(this.Session.FindElementByClassName, "ContextMenu");
+            var exitItem = menu.FindElementByName("Exit");
             exitItem.Click();
             notification.Click();
         }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Sessions/FirefoxPrivateVPNSession.cs
@@ -34,7 +34,7 @@ namespace FirefoxPrivateVPNUITest
 
                 try
                 {
-                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities, TimeSpan.FromSeconds(Constants.SessionTimeoutInSeconds));
                     Assert.IsNotNull(this.Session);
                 }
                 catch (Exception)
@@ -50,7 +50,7 @@ namespace FirefoxPrivateVPNUITest
 
                     appCapabilities.SetCapability("app", null);
                     appCapabilities.SetCapability("appTopLevelWindow", applicationSessionHandle);
-                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities);
+                    this.Session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appCapabilities, TimeSpan.FromSeconds(Constants.SessionTimeoutInSeconds));
                     Assert.IsNotNull(this.Session);
                 }
 

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ConnectionTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/ConnectionTest.cs
@@ -74,12 +74,6 @@ namespace FirefoxPrivateVPNUITest
             // User turns on VPN
             UserCommonOperation.ConnectVPN(this.vpnClient, this.desktop);
 
-            // Verify city via Mullvad API
-            var cityResponse = Utils.GetCityViaMullvad(prevCity);
-            Console.WriteLine($"Before switching (server connected) - Mullvad city API response: {cityResponse.Content}");
-            Assert.AreEqual(HttpStatusCode.OK, cityResponse.StatusCode);
-            Assert.IsTrue(prevCity.Contains(cityResponse.Content.Trim()));
-
             // Click the server button
             mainScreen = new MainScreen(this.vpnClient.Session);
             mainScreen.ClickServerListButton();
@@ -99,12 +93,6 @@ namespace FirefoxPrivateVPNUITest
             Assert.AreEqual(string.Format("From {0} to {1}", prevCity, currentCity), windowsNotificationScreen.GetTitleText());
             Assert.AreEqual("You switched servers.", windowsNotificationScreen.GetMessageText());
             windowsNotificationScreen.ClickDismissButton();
-
-            // Verify city via Mullvad API
-            cityResponse = Utils.GetCityViaMullvad(currentCity);
-            Console.WriteLine($"After switching (server connected) - Mullvad city API response: {cityResponse.Content}");
-            Assert.AreEqual(HttpStatusCode.OK, cityResponse.StatusCode);
-            Assert.IsTrue(currentCity.Contains(cityResponse.Content.Trim()));
 
             // User turns off VPN
             UserCommonOperation.DisconnectVPN(this.vpnClient, this.desktop);

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/NewUserSignInTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/NewUserSignInTest.cs
@@ -4,6 +4,7 @@
 
 namespace FirefoxPrivateVPNUITest
 {
+    using System;
     using FirefoxPrivateVPNUITest.Screens;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,7 +12,6 @@ namespace FirefoxPrivateVPNUITest
     /// This Sign In test is for new users.
     /// </summary>
     [TestClass]
-    [Ignore]
     public class NewUserSignInTest
     {
         private FirefoxPrivateVPNSession vpnClient;
@@ -30,6 +30,9 @@ namespace FirefoxPrivateVPNUITest
             var vpnClientPosition = this.vpnClient.Session.Manage().Window.Position;
             var vpnClientSize = this.vpnClient.Session.Manage().Window.Size;
             this.browser.SetWindowPosition(vpnClientPosition.X + vpnClientSize.Width, 0);
+
+            // Delete email from restmail.net
+            Assert.IsTrue(Utils.DeleteUserFromRestMail(Constants.NewUserName));
         }
 
         /// <summary>
@@ -53,21 +56,87 @@ namespace FirefoxPrivateVPNUITest
             LandingScreen landingScreen = new LandingScreen(this.vpnClient.Session);
             landingScreen.ClickGetStartedButton();
 
+            // Verify Account Screen
+            this.vpnClient.Session.SwitchTo();
+            VerifyAccountScreen verifyAccountScreen = new VerifyAccountScreen(this.vpnClient.Session);
+            Assert.AreEqual("Waiting for sign in and subscription confirmation...", verifyAccountScreen.GetTitle());
+            Assert.AreEqual("Cancel and try again", verifyAccountScreen.GetCancelTryAgainButtonText());
+
             // Switch to Browser session
             this.browser.Session.SwitchTo();
-            EmailInputPage loginScreen = new EmailInputPage(this.browser.Session);
-            loginScreen.InputEmail("mhuang+123456@connected.io");
-            loginScreen.ClickContinueButton();
+
+            // Email Input page
+            EmailInputPage emailInputPage = new EmailInputPage(this.browser.Session);
+            emailInputPage.InputEmail(Constants.NewUserEmail);
+            emailInputPage.ClickContinueButton();
+
+            // Registration password Input Page
             RegisterPage registerPage = new RegisterPage(this.browser.Session);
-            registerPage.InputPassword("Passw0rd!");
-            registerPage.InputRepeatPassword("Passw0rd!");
-            registerPage.InputAge("30");
+            registerPage.InputPassword(Environment.GetEnvironmentVariable("EXISTED_USER_PASSWORD"));
+            registerPage.InputRepeatPassword(Environment.GetEnvironmentVariable("EXISTED_USER_PASSWORD"));
+            registerPage.InputAge("50");
             registerPage.ClickCreateAccountButton();
 
-            // TODO: need to insert a predicatable verification code
-            // TODO: set up subscription payment
-            // TODO: switch back to VPN client and click continue
-            // TODO: Sign out
+            // Get verification code from API
+            string verificationCode = Utils.GetVerificationCode(Constants.NewUserName);
+
+            // Enter verification code page
+            VerificationCodePage verificationCodePage = new VerificationCodePage(this.browser.Session);
+            verificationCodePage.InputVerificationCode(verificationCode);
+            verificationCodePage.ClickVerifyButton();
+
+            // Enter subscription page
+            string subscriptionPageUrl = string.Empty;
+            Utils.WaitUntil(ref subscriptionPageUrl, (str) => this.browser.GetCurrentUrl(), null, (str) => str.Contains(Constants.KeyWordInPaymentUrl));
+            SubscriptionPage subscriptionPage = new SubscriptionPage(this.browser.Session);
+            subscriptionPage.InputFullName(Constants.NewUserName);
+            subscriptionPage.InputCardNumber(Environment.GetEnvironmentVariable("NEW_USER_CARD_NUMBER"));
+            subscriptionPage.InputExpDate(Environment.GetEnvironmentVariable("NEW_USER_CARD_EXP_DATE"));
+            subscriptionPage.InputCVC(Environment.GetEnvironmentVariable("NEW_USER_CARD_CVC"));
+            subscriptionPage.InputZipCode(Environment.GetEnvironmentVariable("NEW_USER_ZIP_CODE"));
+            subscriptionPage.ClickAuthorizeCheckBox();
+            subscriptionPage.ClickSubmitButton();
+
+            // Subscription Success Page
+            SubscriptionSuccessPage subscriptionSuccessPage = new SubscriptionSuccessPage(this.browser.Session);
+            subscriptionSuccessPage.ClickTakeMeToProductLink();
+
+            // Quick Access Screen
+            this.vpnClient.Session.SwitchTo();
+            QuickAccessScreen quickAccessScreen = new QuickAccessScreen(this.vpnClient.Session);
+            Assert.AreEqual("Quick access", quickAccessScreen.GetTitle());
+            Assert.AreEqual("You can quickly access Firefox Private Network from your taskbar tray", quickAccessScreen.GetSubTitle());
+            Assert.AreEqual("Located next to the clock at the bottom right of your screen", quickAccessScreen.GetDescription());
+            quickAccessScreen.ClickContinueButton();
+
+            // On main screen
+            MainScreen main = new MainScreen(this.vpnClient.Session);
+            main.ClickSettingsButton();
+
+            // On setting screen
+            SettingScreen settingScreen = new SettingScreen(this.vpnClient.Session);
+            settingScreen.ClickManageAccountButton();
+
+            // Open an account page in browser
+            this.browser.Session.SwitchTo();
+            emailInputPage = new EmailInputPage(this.browser.Session);
+            emailInputPage.InputEmail(Constants.NewUserEmail);
+            emailInputPage.ClickContinueButton();
+
+            // Go to password input page
+            PasswordInputPage passwordInputPage = new PasswordInputPage(this.browser.Session);
+            passwordInputPage.InputPassword(Environment.GetEnvironmentVariable("EXISTED_USER_PASSWORD"));
+            passwordInputPage.ClickSignInButton();
+
+            // Go to account management page
+            ManageAccountPage manageAccountPage = new ManageAccountPage(this.browser.Session);
+            manageAccountPage.ClickDeleteButton();
+            manageAccountPage.ConfirmDeleteAccount(Environment.GetEnvironmentVariable("EXISTED_USER_PASSWORD"));
+
+            // User sign out
+            this.vpnClient.Session.SwitchTo();
+            settingScreen.ScrollDown();
+            settingScreen.ClickSignOutButton();
         }
     }
 }

--- a/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/UtilsTest.cs
+++ b/test/smoke/FirefoxPrivateVPNUITest/FirefoxPrivateVPNUITest/Tests/UtilsTest.cs
@@ -4,6 +4,7 @@
 
 namespace FirefoxPrivateVPNUITest
 {
+    using System;
     using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,8 +25,17 @@ namespace FirefoxPrivateVPNUITest
 
             int randomIndex2 = Utils.RandomSelectIndex(Enumerable.Range(0, 2), (number) => number != 0);
             Assert.AreNotEqual(0, randomIndex2);
+
+            int randomIndex3 = Utils.RandomSelectIndex(Enumerable.Range(0, 0), (number) => true);
+            Assert.AreEqual(-1, randomIndex3);
+
+            int randomIndex4 = Utils.RandomSelectIndex(Enumerable.Range(0, 1), (number) => number != 0);
+            Assert.AreEqual(-1, randomIndex4);
         }
 
+        /// <summary>
+        /// Test CleanText() method.
+        /// </summary>
         [TestMethod]
         public void TestCleanText()
         {

--- a/test/smoke/aws/create_ec2.ps1
+++ b/test/smoke/aws/create_ec2.ps1
@@ -15,8 +15,12 @@ $p9 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{Paramet
 $p10 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="StageUrl"; ParameterValue="$env:STAGE_URL"}
 $p11 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="TestExistedUserName"; ParameterValue="$env:EXISTED_USER_NAME"}
 $p12 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="TestExistedPassword"; ParameterValue="$env:EXISTED_PASSWORD"}
+$p13 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="TestNewUserCardNumber"; ParameterValue="$env:NEW_USER_CARD_NUMBER"}
+$p14 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="TestNewUserCardExpDate"; ParameterValue="$env:NEW_USER_CARD_EXP_DATE"}
+$p15 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="TestNewUserCardCVC"; ParameterValue="$env:NEW_USER_CARD_CVC"}
+$p16 = new-object -Type Amazon.CloudFormation.Model.Parameter -Property @{ParameterKey="TestNewUserZipCode"; ParameterValue="$env:NEW_USER_ZIP_CODE"}
 
-$params = @($p1,$p2,$p3,$p4,$p5,$p6,$p7,$p8,$p9,$p10,$p11,$p12)
+$params = @($p1,$p2,$p3,$p4,$p5,$p6,$p7,$p8,$p9,$p10,$p11,$p12,$p13,$p14,$p15,$p16)
 
 $stack = "guardian-stack-$env:CIRCLE_BUILD_NUM"
 # create stack

--- a/test/smoke/aws/template.json
+++ b/test/smoke/aws/template.json
@@ -67,6 +67,22 @@
       "Description" : "existed user name for testing",
       "Type": "String"
     },
+    "TestNewUserCardNumber": {
+      "Description" : "new user card number for testing",
+      "Type": "String"
+    },
+    "TestNewUserCardExpDate": {
+      "Description" : "new user card exp date for testing",
+      "Type": "String"
+    },
+    "TestNewUserCardCVC": {
+      "Description" : "new user card cvc for testing",
+      "Type": "String"
+    },
+    "TestNewUserZipCode": {
+      "Description" : "new user zip code for testing",
+      "Type": "String"
+    },
     "TestExistedPassword": {
       "Description" : "existed user password for testing",
       "Type": "String"
@@ -116,6 +132,26 @@
                 "[Environment]::SetEnvironmentVariable('EXISTED_USER_PASSWORD', '",
                 {
                   "Ref": "TestExistedPassword"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "[Environment]::SetEnvironmentVariable('NEW_USER_CARD_NUMBER', '",
+                {
+                  "Ref": "TestNewUserCardNumber"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "[Environment]::SetEnvironmentVariable('NEW_USER_CARD_EXP_DATE', '",
+                {
+                  "Ref": "TestNewUserCardExpDate"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "[Environment]::SetEnvironmentVariable('NEW_USER_CARD_CVC', '",
+                {
+                  "Ref": "TestNewUserCardCVC"
+                },
+                "', [EnvironmentVariableTarget]::Machine) \n",
+                "[Environment]::SetEnvironmentVariable('NEW_USER_ZIP_CODE', '",
+                {
+                  "Ref": "TestNewUserZipCode"
                 },
                 "', [EnvironmentVariableTarget]::Machine) \n",
 


### PR DESCRIPTION
We add new user login UI test. During this test, we make use of restmail as our fake email address to register fxa account. After everything is done, we remove the account from both restmail and fxa. At the same time, we remove the city verification from connection test and update the timeout for all sessions. In the meantime, we update setting UI test since the UI updated recently.