### PR TITLE
Remove spaces in UserAgent product name.

### DIFF
--- a/ui/src/ProductConstants.cs
+++ b/ui/src/ProductConstants.cs
@@ -265,7 +265,7 @@ namespace FirefoxPrivateNetwork
         {
             var osVersion = Environment.OSVersion.ToString();
             var osBits = Environment.Is64BitOperatingSystem ? "x64" : "x86";
-            return string.Format("{0}/{1} ({2}; {3})", ProductName, GetVersion(), osVersion, osBits);
+            return string.Format("{0}/{1} ({2}; {3})", InternalAppName, GetVersion(), osVersion, osBits);
         }
 
         /// <summary>


### PR DESCRIPTION
To be consistent with ios - https://github.com/mozilla-mobile/guardian-vpn-ios/commit/ddb54a20d1a4ee315158f668220aa2f0ec07fada