### PR TITLE
ui: Fix language change refresh in the main card

### DIFF
--- a/ui/src/UI/Views/MainView.xaml.cs
+++ b/ui/src/UI/Views/MainView.xaml.cs
@@ -24,6 +24,7 @@ namespace FirefoxPrivateNetwork.UI
         {
             InitializeComponent();
             DataContext = Manager.MainWindowViewModel;
+            ConfigureDataContextChangedHandler();
 
             // Reinitialize UI values
             ReinitializeUI();
@@ -32,8 +33,17 @@ namespace FirefoxPrivateNetwork.UI
         private void ReinitializeUI()
         {
             InitializeConnectionNavButton();
-
             Manager.AccountInfoUpdater.RefreshDeviceList();
+        }
+
+        private void ConfigureDataContextChangedHandler()
+        {
+            DataContextChanged += new DependencyPropertyChangedEventHandler((sender, e) =>
+            {
+                // Update the data context of the card within the main view
+                MainCard.DataContext = null;
+                MainCard.DataContext = Manager.MainWindowViewModel;
+            });
         }
 
         private void InitializeConnectionNavButton()


### PR DESCRIPTION
These changes address the bug where a language change within the
application does not immediately refresh the data context of the card
(which is required to load the new localized strings) within the main
view.