### PR TITLE
ui: Seperated avatar image download task from the UI thread

### DIFF
--- a/ui/src/Firefox Private Network.csproj
+++ b/ui/src/Firefox Private Network.csproj
@@ -339,6 +339,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ErrorHandling\UserFacingMessage.cs" />
+    <Compile Include="FxA\Avatar.cs" />
     <Compile Include="FxA\IpInfo.cs" />
     <Compile Include="FxA\RangeConverter.cs" />
     <Compile Include="FxA\ServerList\VPNServer.cs" />

--- a/ui/src/FxA/Account.cs
+++ b/ui/src/FxA/Account.cs
@@ -46,6 +46,7 @@ namespace FirefoxPrivateNetwork.FxA
             if (Config.LoadFxAToken() && Config.LoadFxAUserFromFile(ProductConstants.FxAUserFile))
             {
                 LoginState = LoginState.LoggedIn;
+                Avatar.InitializeCache(avatarUrl: Config.FxALogin.User.Avatar);
             }
         }
 
@@ -53,6 +54,11 @@ namespace FirefoxPrivateNetwork.FxA
         /// Gets or sets the config structure associated with this account.
         /// </summary>
         public Config Config { get; set; } = new Config();
+
+        /// <summary>
+        /// Gets or sets the avatar associated with this account.
+        /// </summary>
+        public Avatar Avatar { get; set; } = new Avatar();
 
         /// <summary>
         /// Gets or sets the current login state indicating whether the user is logged in, is in the process of logging in or logged out.
@@ -84,7 +90,7 @@ namespace FirefoxPrivateNetwork.FxA
             Manager.Account.LoginState = FxA.LoginState.LoggedIn;
 
             // Initialize cache for avatar image
-            Manager.InitializeCache();
+            Manager.Account.Avatar.InitializeCache(avatarUrl: Config.FxALogin.User.Avatar);
 
             // Added a new account device through the FxA API, using the newly generated keypair
             var devices = new FxA.Devices();
@@ -139,7 +145,7 @@ namespace FirefoxPrivateNetwork.FxA
                 File.Delete(ProductConstants.FirefoxPrivateNetworkConfFile);
 
                 // Clear the cache for avatar image
-                Manager.ClearCache();
+                Manager.Account.Avatar.ClearCache();
 
                 // Set logged out state and terminate UI Updater threads
                 LoginState = LoginState.LoggedOut;

--- a/ui/src/FxA/Avatar.cs
+++ b/ui/src/FxA/Avatar.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="Avatar.cs" company="Mozilla">
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.Caching;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media.Imaging;
+
+namespace FirefoxPrivateNetwork.FxA
+{
+    /// <summary>
+    /// The user's avatar associated with their FxA account.
+    /// </summary>
+    public class Avatar
+    {
+        private readonly TimeSpan maxAvatarDownloadTime = TimeSpan.FromSeconds(30);
+        private Task<BitmapImage> downloadTask;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Avatar"/> class.
+        /// </summary>
+        public Avatar()
+        {
+            InitializeCache();
+        }
+
+        /// <summary>
+        /// Gets or sets the cache for avatar image.
+        /// </summary>
+        public ObjectCache Cache { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the default avatar image is used.
+        /// </summary>
+        public bool DefaultImage { get; set; } = true;
+
+        /// <summary>
+        /// Initializes cache.
+        /// </summary>
+        /// <param name="avatarUrl">The download URL of the avatar image.</param>
+        /// <returns>The avatar download task, if applicable.</returns>
+        public Task<BitmapImage> InitializeCache(string avatarUrl = null)
+        {
+            // Return the avatar download task if already running
+            if (downloadTask != null && downloadTask.Status.Equals(TaskStatus.Running))
+            {
+                return downloadTask;
+            }
+
+            // Initialize the cache to the default avatar image
+            Cache = MemoryCache.Default;
+            CacheItemPolicy policy = new CacheItemPolicy();
+            Cache.Set("avatarImage", GetDefaultAvatarImage(), policy);
+
+            if (avatarUrl == null)
+            {
+                return null;
+            }
+
+            // Attempt to retreive the avatar image if a download URL is provided
+            downloadTask = Task.Run(() =>
+            {
+                var image = GetAvatarImageWithURL(avatarUrl);
+
+                if (image != null)
+                {
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        Cache.Set("avatarImage", image, policy);
+                    });
+
+                    DefaultImage = false;
+                    return image;
+                }
+
+                return null;
+            });
+
+            return downloadTask;
+        }
+
+        /// <summary>
+        /// Clears cache.
+        /// </summary>
+        public void ClearCache()
+        {
+            Cache.Remove("avatarImage");
+        }
+
+        /// <summary>
+        /// Gets the default avatar image.
+        /// </summary>
+        /// <returns>
+        /// Default avatar image.
+        /// </returns>
+        public BitmapImage GetDefaultAvatarImage()
+        {
+            var defaultAvatarImage = new BitmapImage(new Uri("pack://application:,,,/UI/Resources/Icons/Generic/default-avatar.png"));
+            defaultAvatarImage.Freeze();
+            return defaultAvatarImage;
+        }
+
+        /// <summary>
+        /// Gets the avatar image from Url.
+        /// </summary>
+        /// <returns>
+        /// User's avatar image.
+        /// </returns>
+        /// <param name="url">The URL of the avatar image.</param>
+        public BitmapImage GetAvatarImageWithURL(string url)
+        {
+            var image = new BitmapImage();
+
+            try
+            {
+                if (string.IsNullOrEmpty(url))
+                {
+                    throw new ArgumentNullException();
+                }
+
+                HttpWebRequest req = (HttpWebRequest)WebRequest.Create(url);
+                req.Timeout = (int)maxAvatarDownloadTime.TotalMilliseconds;
+
+                using (HttpWebResponse response = (HttpWebResponse)req.GetResponse())
+                {
+                    using (Stream stream = response.GetResponseStream())
+                    {
+                        Bitmap bitmap = new Bitmap(stream);
+
+                        using (var memoryStream = new MemoryStream())
+                        {
+                            bitmap.Save(memoryStream, ImageFormat.Png);
+                            image.BeginInit();
+                            image.CacheOption = BitmapCacheOption.OnLoad;
+                            image.StreamSource = memoryStream;
+                            image.EndInit();
+                            image.Freeze();
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorHandling.ErrorHandler.Handle(e, ErrorHandling.LogLevel.Debug);
+                image = null;
+            }
+
+            return image;
+        }
+    }
+}

--- a/ui/src/Manager.cs
+++ b/ui/src/Manager.cs
@@ -19,11 +19,6 @@ namespace FirefoxPrivateNetwork
     internal class Manager
     {
         /// <summary>
-        /// Gets or sets cache for avatar image.
-        /// </summary>
-        public static ObjectCache Cache { get; set; }
-
-        /// <summary>
         /// Gets or sets the application tray icon handler.
         /// </summary>
         public static NotificationArea.Tray TrayIcon { get; set; }
@@ -124,7 +119,6 @@ namespace FirefoxPrivateNetwork
             InitializeCaptivePortalDetector();
             InitializeIpInfo();
             InitializeUIUpdaters();
-            InitializeCache();
         }
 
         /// <summary>
@@ -260,85 +254,6 @@ namespace FirefoxPrivateNetwork
             var migSettings = new Migrations.Settings();
             migSettings.MigrateConfigAddressToSettingsFile();
             Settings = new Settings(ProductConstants.SettingsFile);
-        }
-
-        /// <summary>
-        /// Gets the default avatar image.
-        /// </summary>
-        /// <returns>
-        /// Default avatar image.
-        /// </returns>
-        public static BitmapImage GetDefaultAvatarImage()
-        {
-            return new BitmapImage(new Uri("pack://application:,,,/UI/Resources/Icons/Generic/default-avatar.png"));
-        }
-
-        /// <summary>
-        /// Gets the avatar image from Url.
-        /// </summary>
-        /// <returns>
-        /// User's avatar image.
-        /// </returns>
-        public static BitmapImage GetAvatarImageWithURL()
-        {
-            var image = new BitmapImage();
-
-            HttpWebRequest req = (HttpWebRequest)WebRequest.Create(Account.Config.FxALogin.User.Avatar);
-
-            try
-            {
-                using (HttpWebResponse response = (HttpWebResponse)req.GetResponse())
-                {
-                    image = new BitmapImage(new Uri(Account.Config.FxALogin.User.Avatar));
-                }
-            }
-            catch (Exception e)
-            {
-                ErrorHandling.ErrorHandler.Handle(e, ErrorHandling.LogLevel.Debug);
-                image = GetDefaultAvatarImage();
-            }
-
-            return image;
-        }
-
-        /// <summary>
-        /// Initializes cache.
-        /// </summary>
-        public static void InitializeCache()
-        {
-            Cache = MemoryCache.Default;
-
-            if (Account.LoginState == FxA.LoginState.LoggedIn)
-            {
-                CacheItemPolicy policy = new CacheItemPolicy();
-
-                Task.Run(() =>
-                {
-                    Application.Current.Dispatcher.Invoke(() =>
-                    {
-                        var image = new BitmapImage();
-
-                        if (Account.Config.FxALogin.User.Avatar != null)
-                        {
-                            image = GetAvatarImageWithURL();
-                        }
-                        else
-                        {
-                            image = GetDefaultAvatarImage();
-                        }
-
-                        Cache.Set("avatarImage", image, policy);
-                    });
-                });
-            }
-        }
-
-        /// <summary>
-        /// Clears cache.
-        /// </summary>
-        public static void ClearCache()
-        {
-            Cache.Remove("avatarImage");
         }
     }
 }

--- a/ui/src/UI/Components/Card/Avatar/Avatar.xaml
+++ b/ui/src/UI/Components/Card/Avatar/Avatar.xaml
@@ -100,7 +100,7 @@
                         <ControlTemplate TargetType="{x:Type ToggleButton}">
                             <Ellipse>
                                 <Ellipse.Fill>
-                                    <ImageBrush RenderOptions.BitmapScalingMode="HighQuality" RenderOptions.EdgeMode="Aliased" Stretch="Uniform" ImageSource="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Avatar}}, Path=AvatarImage, TargetNullValue={x:Null}}"/>
+                                    <ImageBrush x:Name="ProfileImage" RenderOptions.BitmapScalingMode="HighQuality" RenderOptions.EdgeMode="Aliased" Stretch="Uniform" ImageSource="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:Avatar}}, Path=AvatarImage, TargetNullValue={x:Null}}"/>
                                 </Ellipse.Fill>
                             </Ellipse>
                         </ControlTemplate>


### PR DESCRIPTION
These changes address the bug where the avatar image is being downloaded
in the UI thread, causing potential hanging.  The avatar image cache is
now refactored and the image is downloaded in a seperate task.