### PR TITLE
ui: Refresh avatar image on load

### DIFF
--- a/ui/src/FxA/Avatar.cs
+++ b/ui/src/FxA/Avatar.cs
@@ -39,9 +39,9 @@ namespace FirefoxPrivateNetwork.FxA
         public ObjectCache Cache { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the default avatar image is used.
+        /// Gets or sets the url of the avatar image.
         /// </summary>
-        public bool DefaultImage { get; set; } = true;
+        public string Url { get; set; }
 
         /// <summary>
         /// Initializes cache.
@@ -73,12 +73,13 @@ namespace FirefoxPrivateNetwork.FxA
 
                 if (image != null)
                 {
+                    Url = avatarUrl;
+
                     Application.Current.Dispatcher.Invoke(() =>
                     {
                         Cache.Set("avatarImage", image, policy);
                     });
 
-                    DefaultImage = false;
                     return image;
                 }
 

--- a/ui/src/UI/Components/Card/Avatar/Avatar.xaml
+++ b/ui/src/UI/Components/Card/Avatar/Avatar.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:FirefoxPrivateNetwork.UI.Components"
              mc:Ignorable="d" 
+             Loaded="Avatar_Loaded"
              d:DesignHeight="450" d:DesignWidth="800">
     
     <Grid>


### PR DESCRIPTION
This change ensures that the user's latest avatar image URL is fetched
when the avatar user control is loaded.