### PR TITLE
Refresh selected server every time before connecting/switching

### DIFF
--- a/ui/src/UI/Views/ConnectionView.xaml.cs
+++ b/ui/src/UI/Views/ConnectionView.xaml.cs
@@ -46,7 +46,6 @@ namespace FirefoxPrivateNetwork.UI
 
                 // Set the selected server city and server
                 Manager.MainWindowViewModel.ServerCityListSelectedItem = selectedCity;
-                Manager.MainWindowViewModel.UpdateServerSelection();
 
                 // Switch servers if presently connected, do nothing otherwise
                 if (Manager.MainWindowViewModel.Status == Models.ConnectionState.Protected)

--- a/ui/src/WireGuard/Connector.cs
+++ b/ui/src/WireGuard/Connector.cs
@@ -30,6 +30,8 @@ namespace FirefoxPrivateNetwork.WireGuard
                 address += "," + Manager.Settings.Network.IPv6Address;
             }
 
+            Manager.MainWindowViewModel.UpdateServerSelection();
+
             ErrorHandling.DebugLogger.LogDebugMsg("Setting endpoint to", Manager.MainWindowViewModel.ServerSelected.Endpoint);
             var currentServer = FxA.Cache.FxAServerList.GetServerByIP(Manager.MainWindowViewModel.ServerSelected.Endpoint);
             configuration.SetEndpoint(currentServer.GetEndpointWithRandomPort(), currentServer.PublicKey, ProductConstants.AllowedIPs, address, currentServer.DNSServerAddress);


### PR DESCRIPTION
Since there're multiple places calling Connector#Connect(), I put MainWindowViewModel#UpdateServerSelection() directly in the Connector#Connect(), and remove the calling to it from ConnectionView#RaidoButton_Click since it will eventually be called in Connector#Connect()