### PR TITLE
GUARDIAN-623: A remove device fail message is popped after logout during a vpn connection

### DIFF
--- a/ui/src/FxA/Account.cs
+++ b/ui/src/FxA/Account.cs
@@ -123,15 +123,15 @@ namespace FirefoxPrivateNetwork.FxA
         {
             try
             {
-                // Disconnect the VPN tunnel
-                Manager.Tunnel.Disconnect();
-
                 // Remove the current account device
                 if (removeDevice)
                 {
                     var devices = new FxA.Devices();
                     devices.RemoveDevice(Manager.Account.Config.FxALogin.PublicKey, silent: true);
                 }
+
+                // Disconnect the VPN tunnel
+                Manager.Tunnel.Disconnect();
             }
             catch (Exception)
             {

--- a/ui/src/FxA/ApiRequest.cs
+++ b/ui/src/FxA/ApiRequest.cs
@@ -91,7 +91,8 @@ namespace FirefoxPrivateNetwork.FxA
                 // Empty status response
                 if (response.StatusCode == 0 || response.Content == null)
                 {
-                    ErrorHandling.DebugLogger.LogDebugMsg(response.ErrorMessage);
+                    ErrorHandling.DebugLogger.LogDebugMsg("res=" + request.Resource + 
+                        ", status=" + response.ResponseStatus + ", msg=" + response.ErrorMessage);
                     return null;
                 }
 

--- a/ui/src/FxA/Devices.cs
+++ b/ui/src/FxA/Devices.cs
@@ -76,7 +76,7 @@ namespace FirefoxPrivateNetwork.FxA
             // Execute the request`
             var response = api.SendRequest();
 
-            if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+            if (response != null && response.StatusCode == System.Net.HttpStatusCode.NoContent)
             {
                 Manager.Account.Config.FxALogin.User.Devices.RemoveAll(d => d.PublicKey == publicKey);
                 Manager.Account.Config.WriteFxAUserToFile(ProductConstants.FxAUserFile);


### PR DESCRIPTION
**STR**
There're several potential scenario that will cause this issue
1. Race condition between disconnect and remove-device operations
2. Network unstable
3. Device key is not dispatched yet by the remote server (connect and logout immediately after login)

**Root cause**
Device#RemoveDevice() didn't check the return value of ApiRequest#SendRequest(), which will be null if there's any network error, so a NullReferenceException is thrown outside of this method and get caught by the outer Account#Logout(). This is why the silent flag passed to this method is not respected.

**Solution**
1. Add null-check to the return value of SendRequest(), thus any failure will be handled by RemoveDevice() itself, thus the silent flag will be respected.
2. Adjust the order of disconnect and remove-device to avoid the race condition between them.
3. I also add more detail to the log of SendReqeust() so we can know which api is called

This PR only fix the problem where silent flag is not respected, and also deal with the 1st scenario mentioned in the **STR** section. However, in the 2nd and 3th scenario, though there's no error message popped anymore, the device indeed is not removed due to the network failure.

Potential solution
1. Add a retry mechanism.
2. Record devices that are failed to be removed, and remove them in the future when the network is available.