### PR TITLE
Remove smoke test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,16 +195,16 @@ workflows:
   workflow:
     jobs:
       - build
-  smoke-test:
-    triggers:
-      - schedule:
-          cron: "0 0,12 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build
-      - smoke-test:
-          requires:
-            - build
+ # smoke-test:
+ #   triggers:
+ #     - schedule:
+ #         cron: "0 0,12 * * *"
+ #         filters:
+ #           branches:
+ #             only:
+ #               - master
+ #   jobs:
+ #     - build
+ #     - smoke-test:
+ #         requires:
+ #           - build


### PR DESCRIPTION
**Reason**
1. From the history on the CI server, these smock-tests almost never passes.
2. These tests were put under the smock-test folder but were named as UI-test. After looking at the implementation, I think these tests are neither smock-test nor UI-test and are lack of clear testing scope.

> - For UI-test, these tests depend too heavily on the external environment, such as the website flow, or even the location of the test machine. 

> - For smock-test, they are too complicated and focus too much on the small matters such as the content of a displayed string.

I think we should first determine the testing scope, and properly implement them before scheduling them periodically on the CI server.