### PR TITLE
Updates to PKCE configs

### DIFF
--- a/ui/src/FxA/LoginSessionManager.cs
+++ b/ui/src/FxA/LoginSessionManager.cs
@@ -32,7 +32,7 @@ namespace FirefoxPrivateNetwork.FxA
 
                 sessions.Add(login, tokenSource);
 
-                if (!login.StartLogin(tokenSource.Token))
+                if (!login.StartLogin())
                 {
                     CancelCurrentSession();
                 }

--- a/ui/src/Main.cs
+++ b/ui/src/Main.cs
@@ -3,6 +3,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.ServiceProcess;
 using System.Threading;
@@ -17,7 +19,7 @@ namespace FirefoxPrivateNetwork
     /// Entry point of the Mozilla VPN application.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.StyleCop.CSharp.DocumentationRules", "SA1649:FileNameMustMatchTypeName", Justification = "Default C# behavior.")]
-    internal class Entry : System.Windows.Application
+    internal class Entry : Application
     {
         /// <summary>
         /// Global value that is used to indicate if there is already an instance of the application running.
@@ -32,7 +34,9 @@ namespace FirefoxPrivateNetwork
         {
             bool ranOnStartup = false;
 
-            if (args.Count() == 1)
+            List<Process> processes = Process.GetProcessesByName(Process.GetCurrentProcess().ProcessName).ToList();
+
+            if (args.Count() == 1 && !args[0].Contains("mozilla-vpn:"))
             {
                 // Run the broker child process, skip the UI
                 if (args.First().ToLower() == "broker")
@@ -63,6 +67,7 @@ namespace FirefoxPrivateNetwork
             {
                 // Already running, attempt to send a "show" command to the already running process before exiting
                 var runningWindow = User32.FindWindow(ProductConstants.TrayWindowClassName, string.Empty);
+
                 if (runningWindow != IntPtr.Zero)
                 {
                     User32.SendMessage(runningWindow, User32.WmShow, IntPtr.Zero, string.Empty);
@@ -80,7 +85,6 @@ namespace FirefoxPrivateNetwork
                 var app = new App();
                 app.InitializeComponent();
 
-                // Initialize interfaces
                 Manager.Initialize();
 
                 // Has the app just been launched at Windows startup?

--- a/ui/src/Main.cs
+++ b/ui/src/Main.cs
@@ -36,7 +36,7 @@ namespace FirefoxPrivateNetwork
 
             List<Process> processes = Process.GetProcessesByName(Process.GetCurrentProcess().ProcessName).ToList();
 
-            if (args.Count() == 1 && !args[0].Contains("mozilla-vpn:"))
+            if (args.Count() == 1)
             {
                 // Run the broker child process, skip the UI
                 if (args.First().ToLower() == "broker")

--- a/ui/src/Properties/AssemblyInfo.cs
+++ b/ui/src/Properties/AssemblyInfo.cs
@@ -55,8 +55,8 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]
 [assembly: Guid("b58922b9-3dd6-49a9-8c78-955f657dd0dd")]
 [assembly: NeutralResourcesLanguage("en-US")]
 

--- a/ui/src/UI/Views/Settings/SettingsView.xaml
+++ b/ui/src/UI/Views/Settings/SettingsView.xaml
@@ -82,7 +82,7 @@
                 <!-- Launch VPN on startup setting -->
                 <Grid HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="1" Grid.Column="0">
                     <StackPanel Margin="0,0,0,8">
-                        <CheckBox Margin="18" Content="{Binding Path=[settings-auto-launch]}" Click="RunOnStartup_Click">
+                        <CheckBox Margin="18" Content="{Binding Path=[settings-auto-launch]}" Click="RunOnStartup_Click" Visibility="Hidden">
                             <CheckBox.Style>
                                 <Style BasedOn="{StaticResource Checkbox}" TargetType="{x:Type CheckBox}">
                                     <Setter Property="IsChecked" Value="False" />

--- a/ui/src/WCF/Service.cs
+++ b/ui/src/WCF/Service.cs
@@ -130,7 +130,7 @@ namespace FirefoxPrivateNetwork.WCF
                 var loginInstance = new FxA.Login();
                 var pollInterval = req.PollInterval % 31; // Max 30 seconds, no more
                 Manager.Account.LoginState = FxA.LoginState.LoggingIn;
-                loginInstance.StartQueryLoginThread(req.VerificationUrl, req.PollInterval, req.ExpiresOn, CancellationToken.None);
+                // loginInstance.StartQueryLoginThread(req.VerificationUrl, req.PollInterval, req.ExpiresOn, CancellationToken.None);
                 return new Response(200, "Success");
             }
             catch (Exception ex)


### PR DESCRIPTION
Fixes #144, #143, #142

This update is to fix a bug found with the way PKCE was storing the code verifier on file. It uses a localhost port instead of the mozilla-vpn uri.

This implementation also fixes issues with multiple instances of the VPN client allowed to run, needing UAC each time the client is opened, and issues with the VPN working after signing in.